### PR TITLE
AIR degree as a parameter

### DIFF
--- a/soundcalc/common/utils.py
+++ b/soundcalc/common/utils.py
@@ -22,7 +22,7 @@ def get_proof_system_errors(L_plus: float, params: zkEVMParams):
     e_ALI = L_plus * params.num_columns / params.F
     e_DEEP = (
         L_plus
-        * (4 * (params.trace_length + params.max_combo - 1) + (params.trace_length - 1))
+        * (params.AIR_degree * (params.trace_length + params.max_combo - 1) + (params.trace_length - 1))
         / (params.F - params.trace_length - params.D)
     )
 

--- a/soundcalc/zkevms/miden.py
+++ b/soundcalc/zkevms/miden.py
@@ -23,6 +23,7 @@ class MidenPreset:
 
         # blowup_factor = 8 => rho = 1/8
         rho = 1 / 8.0
+        AIR_degree = 9 # They bound it as 1/rho+1  https://github.com/facebook/winterfell/blob/main/air/src/proof/security.rs#L164
 
         grinding_query_phase = 16
 

--- a/soundcalc/zkevms/risc0.py
+++ b/soundcalc/zkevms/risc0.py
@@ -28,6 +28,7 @@ class Risc0Preset:
         L = C + 4
         s = 50
         max_combo = 9
+        AIR_degree = 4 #They use 5 but in the DEEP-ALI error they use (d-1) so we put 4 here.
 
         FRI_folding_factor = 16
         FRI_early_stop_degree = 2**8
@@ -44,6 +45,7 @@ class Risc0Preset:
             FRI_folding_factor=FRI_folding_factor,
             FRI_early_stop_degree=FRI_early_stop_degree,
             grinding_query_phase=0,
+            AIR_degree=AIR_degree,
         )
         return zkEVMParams(cfg)
 

--- a/soundcalc/zkevms/zkevm.py
+++ b/soundcalc/zkevms/zkevm.py
@@ -31,6 +31,8 @@ class zkEVMConfig:
     num_polys: int
     # Number of FRI queries
     num_queries: int
+    # Maximum constraint degree
+    AIR_degree: int
 
     # FRI folding factor (arity of folding per round)
     FRI_folding_factor: int
@@ -64,6 +66,7 @@ class zkEVMParams:
         self.FRI_folding_factor = zkevm_cfg.FRI_folding_factor
         self.FRI_early_stop_degree = zkevm_cfg.FRI_early_stop_degree
         self.grinding_query_phase = zkevm_cfg.grinding_query_phase
+        self.AIR_degree = zkevm_cfg.AIR_degree
 
         # Number of columns should be less or equal to the final number of polynomials in batched-FRI
         assert self.num_columns <= self.num_polys


### PR DESCRIPTION
Introduces the AIR degree parameter in the formula for DEEP-ALI error, replacing a hard-coded constant from RISC0.