### PR TITLE
Implement proof size estimator

### DIFF
--- a/results.md
+++ b/results.md
@@ -19,6 +19,8 @@ The cell values are the bits of security for each such component.
 - Trace length (H): 2^21
 - Batching: Powers
 
+<b>Proof Size Estimate:</b> 223 KiB, where 1 KiB = 1024 bytes
+
 | regime | ALI | DEEP | FRI batching round | FRI commit round 1 | FRI commit round 2 | FRI commit round 3 | FRI commit round 4 | FRI query phase | PLONK | PLOOKUP | total |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | unique_decoding | 115 | 100 | 92 | 96 | 96 | 96 | 96 | 33 | 98 | 96 | 33 |
@@ -36,6 +38,8 @@ The cell values are the bits of security for each such component.
 - Trace length (H): 2^18
 - Batching: Powers
 
+<b>Proof Size Estimate:</b> 114 KiB, where 1 KiB = 1024 bytes
+
 | regime | ALI | DEEP | FRI batching round | FRI commit round 1 | FRI commit round 2 | FRI commit round 3 | FRI commit round 4 | FRI commit round 5 | FRI commit round 6 | FRI commit round 7 | FRI query phase | PLONK | PLOOKUP | total |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | unique_decoding | 121 | 106 | 100 | 105 | 105 | 105 | 105 | 105 | 105 | 105 | 38 | 106 | 105 | 38 |
@@ -52,6 +56,8 @@ The cell values are the bits of security for each such component.
 - Rate (ρ): 0.5
 - Trace length (H): 2^22
 - Batching: Powers
+
+<b>Proof Size Estimate:</b> 1352 KiB, where 1 KiB = 1024 bytes
 
 | regime | ALI | DEEP | FRI batching round | FRI commit round 1 | FRI commit round 2 | FRI commit round 3 | FRI commit round 4 | FRI commit round 5 | FRI query phase | PLONK | PLOOKUP | total |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |

--- a/soundcalc/common/fields.py
+++ b/soundcalc/common/fields.py
@@ -59,3 +59,8 @@ BABYBEAR_5 = FieldParams(
 )
 
 
+def field_element_size_bits(field: FieldParams) -> int:
+    """
+    Returns the size of a field element in bits.
+    """
+    return math.ceil(math.log2(field.p)) * field.field_extension_degree

--- a/soundcalc/common/fri.py
+++ b/soundcalc/common/fri.py
@@ -51,3 +51,70 @@ def get_FRI_query_phase_error(theta: float, num_queries: int, grinding_bits: int
     FRI_query_phase_error *= 2 ** (-grinding_bits)
 
     return FRI_query_phase_error
+
+def get_size_of_merkle_path_bits(num_leafs: int, tuple_size: int, element_size_bits: int, hash_size_bits: int) -> int:
+    """
+    Compute the size of a Merkle path in bits.
+
+    We assume a Merkle tree that represents num_leafs tuples of elements
+    where each element has size element_size_bits and one tuple contains tuple_size
+    many elements. Each leaf of the tree contains one such tuple.
+
+    Note: the result counts both the leaf itself and the Merkle path.
+    """
+    assert num_leafs > 0
+    leaf_size = tuple_size * element_size_bits
+    sibling = tuple_size * element_size_bits
+    tree_depth = math.ceil(math.log2(num_leafs))
+    co_path = (tree_depth - 1) * hash_size_bits
+    return leaf_size + sibling + co_path
+
+
+def get_FRI_proof_size_bits(
+        hash_size_bits: int,
+        field_size_bits: int,
+        num_functions: int,
+        num_queries: int,
+        witness_size: int,
+        field_extension_degree: int,
+        early_stop_degree: int,
+        folding_factor: int,
+) -> int:
+
+    """
+    Compute the proof size of a (BCS-transformed) FRI interaction in bits.
+    """
+
+    # TODO: the following things are not yet considered.
+    #   - is there really a Merkle root (and paths) for the final round? Or just the codeword itself?
+
+    # The FRI proof contains two parts: Merkle roots, and one "openings" per query,
+    # where an "opening" is a Merkle path for each folding layer.
+    #
+    # We use the same loop as in `get_num_FRI_folding_rounds`, and count the size that
+    # this layer contributes, which includes the root and all Merkle paths.
+
+    size_bits = 0
+
+    # Initial Round: one root and one path per query
+    # We assume that for the initial functions, there is only one Merkle root, and
+    # each leaf i for that root contains symbols i for all initial functions.
+    n = int(witness_size)
+    num_leafs = n // int(folding_factor)
+    tuple_size = num_functions
+    size_bits += hash_size_bits + num_queries * get_size_of_merkle_path_bits(num_leafs, tuple_size, field_size_bits, hash_size_bits)
+
+
+    # Folding rounds
+    # We assume that "siblings" for the following layers are grouped together
+    # in one leaf. This is natural as they always need to be opened together.
+
+    # TODO: need to check if that is actually the correct loop
+    while n // int(folding_factor * field_extension_degree) >= int(early_stop_degree):
+        n //= int(folding_factor)
+        num_leafs = n // int(folding_factor)
+        tuple_size = folding_factor
+        # one root and one path per query
+        size_bits += hash_size_bits + num_queries * get_size_of_merkle_path_bits(num_leafs, tuple_size, field_size_bits, hash_size_bits)
+
+    return size_bits

--- a/soundcalc/common/utils.py
+++ b/soundcalc/common/utils.py
@@ -4,6 +4,8 @@ from ..zkevms.zkevm import zkEVMParams
 
 import math
 
+KIB = (1024 * 8) # Kilobytes
+
 def get_rho_plus(H: int, D: float, max_combo: int) -> float:
     """Compute rho+. See page 16 of Ha22"""
     # XXX Should this be (H + 2) / D? This part is cryptic in [Ha22]

--- a/soundcalc/main.py
+++ b/soundcalc/main.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import json
 
-from soundcalc.common.utils import get_proof_system_levels
+from soundcalc.common.utils import KIB, get_proof_system_levels
 from soundcalc.regimes.best_attack import best_attack_security
 from soundcalc.zkevms.risc0 import Risc0Preset
 from soundcalc.zkevms.miden import MidenPreset
@@ -63,7 +63,11 @@ def print_summary_for_zkevm(zkevm_params, results: dict[str, dict]) -> None:
     Print a summary of security results for a single zkEVM.
     """
     print(f"zkEVM: {zkevm_params.name}")
+    proof_size_kib = zkevm_params.proof_size_bits // KIB
+    print(f"    proof size estimate: {proof_size_kib} KiB, where 1 KiB = 1024 bytes")
     print(json.dumps(results, indent=4))
+    print("")
+    print("")
 
 
 def main() -> None:

--- a/soundcalc/report.py
+++ b/soundcalc/report.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import math
 from typing import Dict, Any, List, Tuple
 
+from soundcalc.common.utils import KIB
+
 
 
 def build_markdown_report(sections) -> str:
@@ -47,6 +49,11 @@ def build_markdown_report(sections) -> str:
             lines.append(f"- Batching: Powers")
         else:
             lines.append(f"- Batching: Affine")
+        lines.append("")
+
+        # Proof size
+        proof_size_kib = zkevm_params.proof_size_bits // KIB
+        lines.append(f"**Proof Size Estimate:** {proof_size_kib} KiB, where 1 KiB = 1024 bytes")
         lines.append("")
 
         # Show results

--- a/soundcalc/zkevms/miden.py
+++ b/soundcalc/zkevms/miden.py
@@ -49,8 +49,11 @@ class MidenPreset:
         # The RECURSIVE_96_BITS config uses algebraic batching
         power_batching = True
 
+        hash_size_bits = 256 # TODO: check if that is actually true
+
         cfg = zkEVMConfig(
             name="miden",
+            hash_size_bits=hash_size_bits,
             rho=rho,
             trace_length=trace_length,
             field=field,

--- a/soundcalc/zkevms/risc0.py
+++ b/soundcalc/zkevms/risc0.py
@@ -38,8 +38,11 @@ class Risc0Preset:
         # Risc0 uses batching with coefficients r^0, r^1, r^2, ...
         power_batching = True
 
+        hash_size_bits = 256 # TODO: check if that is actually true
+
         cfg = zkEVMConfig(
             name="risc0",
+            hash_size_bits=hash_size_bits,
             rho=rho,
             trace_length=trace_length,
             field=field,

--- a/soundcalc/zkevms/zisk.py
+++ b/soundcalc/zkevms/zisk.py
@@ -42,8 +42,11 @@ class ZiskPreset:
 
         max_combo = 3
 
+        hash_size_bits = 256 # TODO: check if that is actually true
+
         cfg = zkEVMConfig(
             name="ZisK",
+            hash_size_bits=hash_size_bits,
             rho=rho,
             trace_length=trace_length,
             field=field,
@@ -58,5 +61,3 @@ class ZiskPreset:
             grinding_query_phase=0,
         )
         return zkEVMParams(cfg)
-
-

--- a/soundcalc/zkevms/zkevm.py
+++ b/soundcalc/zkevms/zkevm.py
@@ -4,8 +4,8 @@ from dataclasses import dataclass
 from typing import Protocol, Mapping, Any
 
 from math import log2
-from ..common.fields import FieldParams
-from ..common.fri import get_num_FRI_folding_rounds
+from ..common.fields import FieldParams, field_element_size_bits
+from ..common.fri import get_FRI_proof_size_bits, get_num_FRI_folding_rounds
 
 
 
@@ -17,6 +17,10 @@ class zkEVMConfig:
 
     # Name of the proof system
     name: str
+
+    # The output length of the hash function that is used in bits
+    # Note: this concerns the hash function used for Merkle trees
+    hash_size_bits: int
 
     # The code rate ρ
     rho: float
@@ -61,6 +65,7 @@ class zkEVMParams:
         """
         # Copy the parameters over (also see docs just above)
         self.name = zkevm_cfg.name
+        self.hash_size_bits = zkevm_cfg.hash_size_bits
         self.rho = zkevm_cfg.rho
         self.trace_length = zkevm_cfg.trace_length
         self.num_columns = zkevm_cfg.num_columns
@@ -97,4 +102,19 @@ class zkEVMParams:
             field_extension_degree=int(self.field_extension_degree),
             folding_factor=int(self.FRI_folding_factor),
             fri_early_stop_degree=int(self.FRI_early_stop_degree),
+        )
+
+        # Compute the proof size
+        # XXX (BW): note that it is not clear that this is the
+        # proof size for every zkEVM we can think of
+        # XXX (BW): we should probably also add something for the OOD samples and plookup, lookup etc.
+        self.proof_size_bits = get_FRI_proof_size_bits(
+            hash_size_bits=self.hash_size_bits,
+            field_size_bits=field_element_size_bits(zkevm_cfg.field),
+            num_functions=self.num_queries,
+            num_queries=self.num_queries,
+            witness_size=int(self.D),
+            field_extension_degree=int(self.field_extension_degree),
+            early_stop_degree=int(self.FRI_early_stop_degree),
+            folding_factor=int(self.FRI_folding_factor),
         )


### PR DESCRIPTION
This is a basic estimator for proof size. Many assumptions need to be revisited, e.g., how values are grouped into Merkle leafs, and how DEEP-ALI impacts things.

Note: this replaces PR #11. 