### PR TITLE
Single VM printing

### DIFF
--- a/soundcalc/__main__.py
+++ b/soundcalc/__main__.py
@@ -1,10 +1,21 @@
 from __future__ import annotations
+import argparse
 
 from .main import main
 
-
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(
+        description="soundcalc - Analyze zkVM security levels"
+    )
+    parser.add_argument(
+        "--print-only",
+        nargs="+",
+        help="Only print specified zkVMs to console (e.g., --print-only ZisK Miden)",
+        default=None,
+    )
+    
+    args = parser.parse_args()
+    main(print_only=args.print_only)
 
 
 

--- a/soundcalc/main.py
+++ b/soundcalc/main.py
@@ -46,7 +46,7 @@ def print_summary_for_zkvm(zkvm: zkVM, security_levels: dict | None = None) -> N
     print("")
     print("")
 
-def main() -> None:
+def main(print_only: list[str] | None = None) -> None:
     """
     Main entry point for soundcalc
 
@@ -67,7 +67,10 @@ def main() -> None:
     # Analyze each zkVM
     for zkvm in zkvms:
         security_levels = zkvm.get_security_levels()
-        print_summary_for_zkvm(zkvm, security_levels)
+
+        if print_only is None or zkvm.get_name() in print_only:
+            print_summary_for_zkvm(zkvm, security_levels)
+
         sections[zkvm.get_name()] = (zkvm, security_levels)
 
     # Generate and save markdown report


### PR DESCRIPTION
This PR adds a command-line argument enabling users to selectively print summaries for specific zkVMs. The main entry point now accepts a `--print-only` argument to control which zkVMs are included in the console output.