### PR TITLE
DEEP ALI Soundness

### DIFF
--- a/soundcalc/zkvms/miden.py
+++ b/soundcalc/zkvms/miden.py
@@ -52,7 +52,7 @@ class MidenPreset:
             n //= FRI_folding_factor
 
         # XXX need to check the numbers below by running the prover
-        num_columns = 100
+        num_constraints = 100
         batch_size = 100
 
         # XXX ???  TODO: ask the main Miden channel
@@ -69,7 +69,7 @@ class MidenPreset:
             rho=rho,
             trace_length=trace_length,
             field=field,
-            num_columns=num_columns,
+            num_constraints=num_constraints,
             batch_size=batch_size,
             power_batching=power_batching,
             num_queries=num_queries,

--- a/soundcalc/zkvms/risc0.py
+++ b/soundcalc/zkvms/risc0.py
@@ -60,7 +60,7 @@ class Risc0Preset:
             rho=rho,
             trace_length=trace_length,
             field=field,
-            num_columns=C,
+            num_constraints=C,
             batch_size=L,
             power_batching=power_batching,
             num_queries=s,

--- a/soundcalc/zkvms/zisk.py
+++ b/soundcalc/zkvms/zisk.py
@@ -31,8 +31,8 @@ class ZiskPreset:
         rho = 1 / blowup_factor
 
         trace_length = 1 << 22
-        num_columns = 66
-        batch_size = num_columns + 2 # +2 for the composition polynomials
+        num_constraints = 66
+        batch_size = num_constraints + 2 # +2 for the composition polynomials
 
         num_queries = 128 // int(math.log2(blowup_factor))
 
@@ -54,7 +54,7 @@ class ZiskPreset:
             rho=rho,
             trace_length=trace_length,
             field=field,
-            num_columns=num_columns,
+            num_constraints=num_constraints,
             batch_size=batch_size,
             power_batching=True,
             num_queries=num_queries,


### PR DESCRIPTION
Following Theorem 8 from [Hab22](https://eprint.iacr.org/2022/1216.pdf):
<img width="1998" height="420" alt="image" src="https://github.com/user-attachments/assets/cb4dd638-f351-4ac0-bd3c-ab4c8667fe5b" />
we should perform the following modifications:
- [x] Update ALI soundness to multiply by the number of constraints instead of columns.
- [ ] Update $L^+$ to take into account the rate $\rho^+$ of the slightly large code with $k^+ = k + \text{numOpenings}$.
- [ ] Add more types of batching, e.g. linear batching, in the DEEP-ALI protocol.
- [ ] Add more types of batching strategies. For instance, if I want to prove the evaluation of $f(X)$ at both $z$ and $g·z$, then I can either run a LDT over functions $g_1(X) = (f(X) - f(z)) / (X - z)$ and $g_2(X) = (f(X) - f(g·z)) / (X - g·z)$ or I can run a LDT over a single function $h(X) = (f(X) - U(X)) / ((X - z)·(X - g·z))$  where $U(X)$ is the unique degree < 2 interpolant through points $(z, f(z))$ and $(g·z, f(g·z))$.
