### PR TITLE
Modifying proof size calculator

### DIFF
--- a/reports/miden.md
+++ b/reports/miden.md
@@ -19,7 +19,7 @@ How to read this report:
 - FRI early stop degree: 128
 - Batching: Powers
 
-**Proof Size Estimate:** 149.0 KiB, where 1 KiB = 1024 bytes
+**Proof Size Estimate:** 136 KiB, where 1 KiB = 1024 bytes
 
 | regime | total | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | commit round 6 | commit round 7 | query phase |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |

--- a/reports/risc0.md
+++ b/reports/risc0.md
@@ -19,7 +19,7 @@ How to read this report:
 - FRI early stop degree: 128
 - Batching: Powers
 
-**Proof Size Estimate:** 380.0 KiB, where 1 KiB = 1024 bytes
+**Proof Size Estimate:** 228 KiB, where 1 KiB = 1024 bytes
 
 | regime | total | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | query phase |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |

--- a/reports/zisk.md
+++ b/reports/zisk.md
@@ -53,11 +53,11 @@ How to read this report:
 - FRI early stop degree: 32
 - Batching: Powers
 
-**Proof Size Estimate:** 699.0 KiB, where 1 KiB = 1024 bytes
+**Proof Size Estimate:** 1128 KiB, where 1 KiB = 1024 bytes
 
 | regime | total | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | query phase |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| UDR | 53 | 186 | 167 | 163 | 169 | 173 | 177 | 181 | 184 | 53 |
+| UDR | 53 | 185 | 167 | 163 | 169 | 173 | 177 | 181 | 184 | 53 |
 | JBR | 49 | 163 | 145 | 49 | 75 | 99 | 123 | 142 | 160 | 63 |
 | best attack | 128 | — | — | — | — | — | — | — | — | — |
 
@@ -77,12 +77,12 @@ How to read this report:
 - FRI early stop degree: 32
 - Batching: Powers
 
-**Proof Size Estimate:** 570.0 KiB, where 1 KiB = 1024 bytes
+**Proof Size Estimate:** 1207 KiB, where 1 KiB = 1024 bytes
 
 | regime | total | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | query phase |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| UDR | 53 | 189 | 168 | 164 | 169 | 173 | 177 | 181 | 184 | 53 |
-| JBR | 51 | 167 | 145 | 51 | 75 | 99 | 123 | 142 | 160 | 63 |
+| UDR | 53 | 187 | 168 | 164 | 169 | 173 | 177 | 181 | 184 | 53 |
+| JBR | 51 | 165 | 145 | 51 | 75 | 99 | 123 | 142 | 160 | 63 |
 | best attack | 128 | — | — | — | — | — | — | — | — | — |
 
 
@@ -101,12 +101,12 @@ How to read this report:
 - FRI early stop degree: 32
 - Batching: Powers
 
-**Proof Size Estimate:** 603.0 KiB, where 1 KiB = 1024 bytes
+**Proof Size Estimate:** 1087 KiB, where 1 KiB = 1024 bytes
 
 | regime | total | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | query phase |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | UDR | 53 | 187 | 167 | 164 | 169 | 173 | 177 | 181 | 184 | 53 |
-| JBR | 50 | 165 | 145 | 50 | 75 | 99 | 123 | 142 | 160 | 63 |
+| JBR | 50 | 164 | 145 | 50 | 75 | 99 | 123 | 142 | 160 | 63 |
 | best attack | 128 | — | — | — | — | — | — | — | — | — |
 
 
@@ -125,12 +125,12 @@ How to read this report:
 - FRI early stop degree: 32
 - Batching: Powers
 
-**Proof Size Estimate:** 537.0 KiB, where 1 KiB = 1024 bytes
+**Proof Size Estimate:** 1016 KiB, where 1 KiB = 1024 bytes
 
 | regime | total | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | query phase |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| UDR | 53 | 188 | 168 | 165 | 170 | 174 | 178 | 181 | 184 | 53 |
-| JBR | 57 | 166 | 147 | 57 | 81 | 105 | 124 | 142 | 160 | 63 |
+| UDR | 53 | 187 | 168 | 165 | 170 | 174 | 178 | 181 | 184 | 53 |
+| JBR | 57 | 165 | 147 | 57 | 81 | 105 | 124 | 142 | 160 | 63 |
 | best attack | 128 | — | — | — | — | — | — | — | — | — |
 
 
@@ -149,12 +149,12 @@ How to read this report:
 - FRI early stop degree: 32
 - Batching: Powers
 
-**Proof Size Estimate:** 561.0 KiB, where 1 KiB = 1024 bytes
+**Proof Size Estimate:** 1024 KiB, where 1 KiB = 1024 bytes
 
 | regime | total | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | query phase |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | UDR | 53 | 187 | 168 | 165 | 170 | 174 | 178 | 181 | 184 | 53 |
-| JBR | 56 | 166 | 147 | 56 | 81 | 105 | 124 | 142 | 160 | 63 |
+| JBR | 56 | 165 | 147 | 56 | 81 | 105 | 124 | 142 | 160 | 63 |
 | best attack | 128 | — | — | — | — | — | — | — | — | — |
 
 
@@ -173,12 +173,12 @@ How to read this report:
 - FRI early stop degree: 32
 - Batching: Powers
 
-**Proof Size Estimate:** 657.0 KiB, where 1 KiB = 1024 bytes
+**Proof Size Estimate:** 1048 KiB, where 1 KiB = 1024 bytes
 
 | regime | total | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | query phase |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | UDR | 53 | 186 | 168 | 164 | 170 | 174 | 178 | 181 | 184 | 53 |
-| JBR | 55 | 165 | 147 | 55 | 81 | 105 | 124 | 142 | 160 | 63 |
+| JBR | 55 | 164 | 147 | 55 | 81 | 105 | 124 | 142 | 160 | 63 |
 | best attack | 128 | — | — | — | — | — | — | — | — | — |
 
 
@@ -197,11 +197,11 @@ How to read this report:
 - FRI early stop degree: 32
 - Batching: Powers
 
-**Proof Size Estimate:** 591.0 KiB, where 1 KiB = 1024 bytes
+**Proof Size Estimate:** 1092 KiB, where 1 KiB = 1024 bytes
 
 | regime | total | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | query phase |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| UDR | 53 | 187 | 167 | 164 | 169 | 173 | 177 | 181 | 184 | 53 |
+| UDR | 53 | 186 | 167 | 164 | 169 | 173 | 177 | 181 | 184 | 53 |
 | JBR | 50 | 164 | 145 | 50 | 75 | 99 | 123 | 142 | 160 | 63 |
 | best attack | 128 | — | — | — | — | — | — | — | — | — |
 
@@ -221,12 +221,12 @@ How to read this report:
 - FRI early stop degree: 32
 - Batching: Powers
 
-**Proof Size Estimate:** 570.0 KiB, where 1 KiB = 1024 bytes
+**Proof Size Estimate:** 1083 KiB, where 1 KiB = 1024 bytes
 
 | regime | total | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | query phase |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | UDR | 53 | 187 | 167 | 164 | 169 | 173 | 177 | 181 | 184 | 53 |
-| JBR | 51 | 165 | 145 | 51 | 75 | 99 | 123 | 142 | 160 | 63 |
+| JBR | 51 | 164 | 145 | 51 | 75 | 99 | 123 | 142 | 160 | 63 |
 | best attack | 128 | — | — | — | — | — | — | — | — | — |
 
 
@@ -245,12 +245,12 @@ How to read this report:
 - FRI early stop degree: 32
 - Batching: Powers
 
-**Proof Size Estimate:** 585.0 KiB, where 1 KiB = 1024 bytes
+**Proof Size Estimate:** 1090 KiB, where 1 KiB = 1024 bytes
 
 | regime | total | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | query phase |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| UDR | 53 | 187 | 167 | 164 | 169 | 173 | 177 | 181 | 184 | 53 |
-| JBR | 51 | 165 | 145 | 51 | 75 | 99 | 123 | 142 | 160 | 63 |
+| UDR | 53 | 186 | 167 | 164 | 169 | 173 | 177 | 181 | 184 | 53 |
+| JBR | 51 | 164 | 145 | 51 | 75 | 99 | 123 | 142 | 160 | 63 |
 | best attack | 128 | — | — | — | — | — | — | — | — | — |
 
 
@@ -269,12 +269,12 @@ How to read this report:
 - FRI early stop degree: 32
 - Batching: Powers
 
-**Proof Size Estimate:** 672.0 KiB, where 1 KiB = 1024 bytes
+**Proof Size Estimate:** 1089 KiB, where 1 KiB = 1024 bytes
 
 | regime | total | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | query phase |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| UDR | 53 | 186 | 168 | 164 | 170 | 174 | 178 | 181 | 184 | 53 |
-| JBR | 55 | 164 | 147 | 55 | 81 | 105 | 124 | 142 | 160 | 63 |
+| UDR | 53 | 185 | 168 | 164 | 170 | 174 | 178 | 181 | 184 | 53 |
+| JBR | 55 | 163 | 147 | 55 | 81 | 105 | 124 | 142 | 160 | 63 |
 | best attack | 128 | — | — | — | — | — | — | — | — | — |
 
 
@@ -293,7 +293,7 @@ How to read this report:
 - FRI early stop degree: 32
 - Batching: Powers
 
-**Proof Size Estimate:** 663.0 KiB, where 1 KiB = 1024 bytes
+**Proof Size Estimate:** 1118 KiB, where 1 KiB = 1024 bytes
 
 | regime | total | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | query phase |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -317,12 +317,12 @@ How to read this report:
 - FRI early stop degree: 32
 - Batching: Powers
 
-**Proof Size Estimate:** 570.0 KiB, where 1 KiB = 1024 bytes
+**Proof Size Estimate:** 1083 KiB, where 1 KiB = 1024 bytes
 
 | regime | total | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | query phase |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | UDR | 53 | 187 | 167 | 164 | 169 | 173 | 177 | 181 | 184 | 53 |
-| JBR | 51 | 165 | 145 | 51 | 75 | 99 | 123 | 142 | 160 | 63 |
+| JBR | 51 | 164 | 145 | 51 | 75 | 99 | 123 | 142 | 160 | 63 |
 | best attack | 128 | — | — | — | — | — | — | — | — | — |
 
 
@@ -341,12 +341,12 @@ How to read this report:
 - FRI early stop degree: 32
 - Batching: Powers
 
-**Proof Size Estimate:** 636.0 KiB, where 1 KiB = 1024 bytes
+**Proof Size Estimate:** 1111 KiB, where 1 KiB = 1024 bytes
 
 | regime | total | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | query phase |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | UDR | 53 | 186 | 167 | 163 | 169 | 173 | 177 | 181 | 184 | 53 |
-| JBR | 50 | 164 | 145 | 50 | 75 | 99 | 123 | 142 | 160 | 63 |
+| JBR | 50 | 163 | 145 | 50 | 75 | 99 | 123 | 142 | 160 | 63 |
 | best attack | 128 | — | — | — | — | — | — | — | — | — |
 
 
@@ -365,12 +365,12 @@ How to read this report:
 - FRI early stop degree: 32
 - Batching: Powers
 
-**Proof Size Estimate:** 659.0 KiB, where 1 KiB = 1024 bytes
+**Proof Size Estimate:** 1050 KiB, where 1 KiB = 1024 bytes
 
 | regime | total | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | query phase |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | UDR | 53 | 185 | 169 | 164 | 171 | 175 | 179 | 183 | 53 |
-| JBR | 61 | 165 | 149 | 61 | 87 | 111 | 135 | 159 | 63 |
+| JBR | 61 | 164 | 149 | 61 | 87 | 111 | 135 | 159 | 63 |
 | best attack | 128 | — | — | — | — | — | — | — | — |
 
 
@@ -389,11 +389,11 @@ How to read this report:
 - FRI early stop degree: 32
 - Batching: Powers
 
-**Proof Size Estimate:** 1754.0 KiB, where 1 KiB = 1024 bytes
+**Proof Size Estimate:** 1032 KiB, where 1 KiB = 1024 bytes
 
 | regime | total | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | query phase |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| UDR | 53 | 186 | 169 | 162 | 171 | 175 | 179 | 183 | 53 |
+| UDR | 53 | 185 | 169 | 162 | 171 | 175 | 179 | 183 | 53 |
 | JBR | 58 | 165 | 149 | 58 | 87 | 111 | 135 | 159 | 63 |
 | best attack | 128 | — | — | — | — | — | — | — | — |
 
@@ -413,11 +413,11 @@ How to read this report:
 - FRI early stop degree: 32
 - Batching: Powers
 
-**Proof Size Estimate:** 2060.0 KiB, where 1 KiB = 1024 bytes
+**Proof Size Estimate:** 1026 KiB, where 1 KiB = 1024 bytes
 
 | regime | total | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | query phase |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| UDR | 53 | 186 | 169 | 161 | 171 | 175 | 179 | 183 | 53 |
+| UDR | 53 | 185 | 169 | 161 | 171 | 175 | 179 | 183 | 53 |
 | JBR | 58 | 165 | 149 | 58 | 87 | 111 | 135 | 159 | 63 |
 | best attack | 128 | — | — | — | — | — | — | — | — |
 
@@ -437,12 +437,12 @@ How to read this report:
 - FRI early stop degree: 32
 - Batching: Powers
 
-**Proof Size Estimate:** 1275.0 KiB, where 1 KiB = 1024 bytes
+**Proof Size Estimate:** 1090 KiB, where 1 KiB = 1024 bytes
 
 | regime | total | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | query phase |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | UDR | 53 | 185 | 168 | 161 | 170 | 174 | 178 | 181 | 184 | 53 |
-| JBR | 53 | 164 | 147 | 53 | 81 | 105 | 124 | 142 | 160 | 63 |
+| JBR | 53 | 163 | 147 | 53 | 81 | 105 | 124 | 142 | 160 | 63 |
 | best attack | 128 | — | — | — | — | — | — | — | — | — |
 
 
@@ -461,7 +461,7 @@ How to read this report:
 - FRI early stop degree: 32
 - Batching: Powers
 
-**Proof Size Estimate:** 4171.0 KiB, where 1 KiB = 1024 bytes
+**Proof Size Estimate:** 932 KiB, where 1 KiB = 1024 bytes
 
 | regime | total | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | query phase |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -485,12 +485,12 @@ How to read this report:
 - FRI early stop degree: 32
 - Batching: Powers
 
-**Proof Size Estimate:** 716.0 KiB, where 1 KiB = 1024 bytes
+**Proof Size Estimate:** 1069 KiB, where 1 KiB = 1024 bytes
 
 | regime | total | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | query phase |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | UDR | 53 | 185 | 169 | 164 | 171 | 175 | 179 | 183 | 53 |
-| JBR | 61 | 165 | 149 | 61 | 87 | 111 | 135 | 159 | 63 |
+| JBR | 61 | 164 | 149 | 61 | 87 | 111 | 135 | 159 | 63 |
 | best attack | 128 | — | — | — | — | — | — | — | — |
 
 
@@ -509,7 +509,7 @@ How to read this report:
 - FRI early stop degree: 32
 - Batching: Powers
 
-**Proof Size Estimate:** 869.0 KiB, where 1 KiB = 1024 bytes
+**Proof Size Estimate:** 1104 KiB, where 1 KiB = 1024 bytes
 
 | regime | total | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | query phase |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -533,12 +533,12 @@ How to read this report:
 - FRI early stop degree: 32
 - Batching: Powers
 
-**Proof Size Estimate:** 974.0 KiB, where 1 KiB = 1024 bytes
+**Proof Size Estimate:** 1139 KiB, where 1 KiB = 1024 bytes
 
 | regime | total | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | query phase |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | UDR | 53 | 184 | 169 | 163 | 171 | 175 | 179 | 183 | 53 |
-| JBR | 60 | 164 | 149 | 60 | 87 | 111 | 135 | 159 | 63 |
+| JBR | 60 | 163 | 149 | 60 | 87 | 111 | 135 | 159 | 63 |
 | best attack | 128 | — | — | — | — | — | — | — | — |
 
 
@@ -557,12 +557,12 @@ How to read this report:
 - FRI early stop degree: 32
 - Batching: Powers
 
-**Proof Size Estimate:** 450.0 KiB, where 1 KiB = 1024 bytes
+**Proof Size Estimate:** 511 KiB, where 1 KiB = 1024 bytes
 
 | regime | total | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | query phase |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| UDR | 43 | 185 | 171 | 164 | 172 | 176 | 180 | 184 | 43 |
-| JBR | 63 | 165 | 151 | 67 | 94 | 118 | 142 | 161 | 63 |
+| UDR | 43 | 184 | 171 | 164 | 172 | 176 | 180 | 184 | 43 |
+| JBR | 63 | 164 | 151 | 67 | 94 | 118 | 142 | 161 | 63 |
 | best attack | 128 | — | — | — | — | — | — | — | — |
 
 
@@ -581,12 +581,12 @@ How to read this report:
 - FRI early stop degree: 32
 - Batching: Powers
 
-**Proof Size Estimate:** 450.0 KiB, where 1 KiB = 1024 bytes
+**Proof Size Estimate:** 511 KiB, where 1 KiB = 1024 bytes
 
 | regime | total | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | query phase |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| UDR | 43 | 185 | 171 | 164 | 172 | 176 | 180 | 184 | 43 |
-| JBR | 63 | 165 | 151 | 67 | 94 | 118 | 142 | 161 | 63 |
+| UDR | 43 | 184 | 171 | 164 | 172 | 176 | 180 | 184 | 43 |
+| JBR | 63 | 164 | 151 | 67 | 94 | 118 | 142 | 161 | 63 |
 | best attack | 128 | — | — | — | — | — | — | — | — |
 
 
@@ -605,12 +605,12 @@ How to read this report:
 - FRI early stop degree: 32
 - Batching: Powers
 
-**Proof Size Estimate:** 450.0 KiB, where 1 KiB = 1024 bytes
+**Proof Size Estimate:** 511 KiB, where 1 KiB = 1024 bytes
 
 | regime | total | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | query phase |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| UDR | 43 | 185 | 171 | 164 | 172 | 176 | 180 | 184 | 43 |
-| JBR | 63 | 165 | 151 | 67 | 94 | 118 | 142 | 161 | 63 |
+| UDR | 43 | 184 | 171 | 164 | 172 | 176 | 180 | 184 | 43 |
+| JBR | 63 | 164 | 151 | 67 | 94 | 118 | 142 | 161 | 63 |
 | best attack | 128 | — | — | — | — | — | — | — | — |
 
 
@@ -629,12 +629,12 @@ How to read this report:
 - FRI early stop degree: 32
 - Batching: Powers
 
-**Proof Size Estimate:** 470.0 KiB, where 1 KiB = 1024 bytes
+**Proof Size Estimate:** 543 KiB, where 1 KiB = 1024 bytes
 
 | regime | total | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | query phase |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| UDR | 43 | 185 | 170 | 163 | 171 | 175 | 179 | 183 | 43 |
-| JBR | 61 | 164 | 149 | 61 | 88 | 112 | 136 | 160 | 63 |
+| UDR | 43 | 184 | 170 | 163 | 171 | 175 | 179 | 183 | 43 |
+| JBR | 61 | 163 | 149 | 61 | 88 | 112 | 136 | 160 | 63 |
 | best attack | 128 | — | — | — | — | — | — | — | — |
 
 
@@ -653,12 +653,12 @@ How to read this report:
 - FRI early stop degree: 32
 - Batching: Powers
 
-**Proof Size Estimate:** 450.0 KiB, where 1 KiB = 1024 bytes
+**Proof Size Estimate:** 511 KiB, where 1 KiB = 1024 bytes
 
 | regime | total | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | query phase |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| UDR | 43 | 185 | 171 | 164 | 172 | 176 | 180 | 184 | 43 |
-| JBR | 63 | 165 | 151 | 67 | 94 | 118 | 142 | 161 | 63 |
+| UDR | 43 | 184 | 171 | 164 | 172 | 176 | 180 | 184 | 43 |
+| JBR | 63 | 164 | 151 | 67 | 94 | 118 | 142 | 161 | 63 |
 | best attack | 128 | — | — | — | — | — | — | — | — |
 
 
@@ -677,12 +677,12 @@ How to read this report:
 - FRI early stop degree: 32
 - Batching: Powers
 
-**Proof Size Estimate:** 450.0 KiB, where 1 KiB = 1024 bytes
+**Proof Size Estimate:** 511 KiB, where 1 KiB = 1024 bytes
 
 | regime | total | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | query phase |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| UDR | 43 | 185 | 171 | 164 | 172 | 176 | 180 | 184 | 43 |
-| JBR | 63 | 165 | 151 | 67 | 94 | 118 | 142 | 161 | 63 |
+| UDR | 43 | 184 | 171 | 164 | 172 | 176 | 180 | 184 | 43 |
+| JBR | 63 | 164 | 151 | 67 | 94 | 118 | 142 | 161 | 63 |
 | best attack | 128 | — | — | — | — | — | — | — | — |
 
 
@@ -701,7 +701,7 @@ How to read this report:
 - FRI early stop degree: 32
 - Batching: Powers
 
-**Proof Size Estimate:** 275.0 KiB, where 1 KiB = 1024 bytes
+**Proof Size Estimate:** 334 KiB, where 1 KiB = 1024 bytes
 
 | regime | total | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | query phase |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -725,7 +725,7 @@ How to read this report:
 - FRI early stop degree: 1024
 - Batching: Powers
 
-**Proof Size Estimate:** 201.0 KiB, where 1 KiB = 1024 bytes
+**Proof Size Estimate:** 252 KiB, where 1 KiB = 1024 bytes
 
 | regime | total | ALI | DEEP | batching | commit round 1 | commit round 2 | query phase |
 | --- | --- | --- | --- | --- | --- | --- | --- |

--- a/soundcalc/common/utils.py
+++ b/soundcalc/common/utils.py
@@ -18,7 +18,23 @@ def get_bits_of_security_from_error(error: float) -> int:
     return int(math.floor(-math.log2(error)))
 
 
-def get_size_of_merkle_path_bits(num_leafs: int, tuple_size: int, element_size_bits: int, hash_size_bits: int) -> int:
+def get_size_of_merkle_path_bits_fri(num_leafs: int, leaf_size_bits: int, hash_size_bits: int, arity: int, last_level_verification: int) -> int:
+    """
+    Compute the size of a Merkle path in bits.
+
+    We assume a Merkle tree that represents num_leafs tuples of elements
+    where each element has size element_size_bits and one tuple contains tuple_size
+    many elements. Each leaf of the tree contains one such tuple.
+
+    Note: the result counts both the leaf itself and the Merkle path.
+    """
+    assert num_leafs > 0
+    sibling = (arity - 1) * hash_size_bits
+    tree_depth = math.ceil(math.log(num_leafs, arity))
+    co_path = (tree_depth - last_level_verification) * hash_size_bits * (arity - 1)
+    return leaf_size_bits + sibling + co_path
+
+def get_size_of_merkle_path_bits_whir(num_leafs: int, tuple_size: int, element_size_bits: int, hash_size_bits: int) -> int:
     """
     Compute the size of a Merkle path in bits.
 

--- a/soundcalc/zkvms/miden/miden.toml
+++ b/soundcalc/zkvms/miden/miden.toml
@@ -24,7 +24,7 @@ trace_length = 262144  # 1 << 18, note that this is smaller than for other VMs, 
 # They bound it as 1/rho+1  https://github.com/facebook/winterfell/blob/main/air/src/proof/security.rs#L164
 air_max_degree = 9
 # XXX need to check the numbers below by running the prover
-num_columns = 100
+num_columns = [100]
 # XXX ???  TODO: ask the main Miden channel
 opening_points = 2
 # XXX need to check the numbers below by running the prover

--- a/soundcalc/zkvms/risc0/risc0.toml
+++ b/soundcalc/zkvms/risc0/risc0.toml
@@ -19,7 +19,7 @@ trace_length = 2097152  # 1 << 21
 # They use 5 but in the DEEP-ALI error they use (d-1) so we put 4 here.
 air_max_degree = 4
 # num_control = 16, num_data = 223, num_accum = 40, C = 279
-num_columns = 279
+num_columns = [279]
 # max_combo = 9
 opening_points = 9
 # L = C + 4 = 283

--- a/soundcalc/zkvms/whir_based_vm.py
+++ b/soundcalc/zkvms/whir_based_vm.py
@@ -7,7 +7,7 @@ import toml
 from soundcalc.common.fields import FieldParams, parse_field
 from soundcalc.common.utils import (
     get_bits_of_security_from_error,
-    get_size_of_merkle_path_bits,
+    get_size_of_merkle_path_bits_whir,
 )
 from soundcalc.proxgaps.johnson_bound import JohnsonBoundRegime
 from soundcalc.proxgaps.proxgaps_regime import ProximityGapsRegime
@@ -607,7 +607,7 @@ class WHIRBasedCircuit(Circuit):
             # Compute the size of one query (path + leaf data)
             #
             # A leaf in WHIR contains an entire folding block (size 2^k).
-            merkle_path_size = get_size_of_merkle_path_bits(
+            merkle_path_size = get_size_of_merkle_path_bits_whir(
                 num_leafs=num_leafs,
                 tuple_size=block_size,
                 element_size_bits=current_element_bits,

--- a/soundcalc/zkvms/zisk/zisk.toml
+++ b/soundcalc/zkvms/zisk/zisk.toml
@@ -11,7 +11,7 @@ group = "basic"
 trace_length = 4194304
 rho = 0.5
 air_max_degree = 3
-num_columns = 51
+num_columns = [3, 38, 24, 6]
 opening_points = 3
 batch_size = 61
 power_batching = true
@@ -19,6 +19,8 @@ num_queries = 128
 fri_folding_factors = [16, 16, 16, 8, 8]
 fri_early_stop_degree = 32
 grinding_query_phase = 0
+merkle_tree_arity = 3
+last_level_verification = 0
 
 [[circuits]]
 name = "Rom"
@@ -26,7 +28,7 @@ group = "basic"
 trace_length = 4194304
 rho = 0.5
 air_max_degree = 2
-num_columns = 5
+num_columns = [1, 1, 6, 3, 11]
 opening_points = 3
 batch_size = 18
 power_batching = true
@@ -34,6 +36,8 @@ num_queries = 128
 fri_folding_factors = [16, 16, 16, 8, 8]
 fri_early_stop_degree = 32
 grinding_query_phase = 0
+merkle_tree_arity = 3
+last_level_verification = 0
 
 [[circuits]]
 name = "Mem"
@@ -41,7 +45,7 @@ group = "basic"
 trace_length = 4194304
 rho = 0.5
 air_max_degree = 3
-num_columns = 20
+num_columns = [2, 13, 9, 6]
 opening_points = 3
 batch_size = 29
 power_batching = true
@@ -49,6 +53,8 @@ num_queries = 128
 fri_folding_factors = [16, 16, 16, 8, 8]
 fri_early_stop_degree = 32
 grinding_query_phase = 0
+merkle_tree_arity = 3
+last_level_verification = 0
 
 [[circuits]]
 name = "RomData"
@@ -56,7 +62,7 @@ group = "basic"
 trace_length = 2097152
 rho = 0.5
 air_max_degree = 3
-num_columns = 13
+num_columns = [2, 6, 9, 6]
 opening_points = 3
 batch_size = 19
 power_batching = true
@@ -64,6 +70,8 @@ num_queries = 128
 fri_folding_factors = [16, 16, 8, 8, 8]
 fri_early_stop_degree = 32
 grinding_query_phase = 0
+merkle_tree_arity = 3
+last_level_verification = 0
 
 [[circuits]]
 name = "InputData"
@@ -71,7 +79,7 @@ group = "basic"
 trace_length = 2097152
 rho = 0.5
 air_max_degree = 3
-num_columns = 19
+num_columns = [2, 9, 14, 6]
 opening_points = 3
 batch_size = 27
 power_batching = true
@@ -79,6 +87,8 @@ num_queries = 128
 fri_folding_factors = [16, 16, 8, 8, 8]
 fri_early_stop_degree = 32
 grinding_query_phase = 0
+merkle_tree_arity = 3
+last_level_verification = 0
 
 [[circuits]]
 name = "MemAlign"
@@ -86,7 +96,7 @@ group = "basic"
 trace_length = 2097152
 rho = 0.5
 air_max_degree = 3
-num_columns = 39
+num_columns = [2, 29, 18, 6]
 opening_points = 3
 batch_size = 59
 power_batching = true
@@ -94,6 +104,8 @@ num_queries = 128
 fri_folding_factors = [16, 16, 8, 8, 8]
 fri_early_stop_degree = 32
 grinding_query_phase = 0
+merkle_tree_arity = 3
+last_level_verification = 0
 
 [[circuits]]
 name = "MemAlignByte"
@@ -101,7 +113,7 @@ group = "basic"
 trace_length = 4194304
 rho = 0.5
 air_max_degree = 3
-num_columns = 23
+num_columns = [1, 16, 12, 6]
 opening_points = 3
 batch_size = 25
 power_batching = true
@@ -109,6 +121,8 @@ num_queries = 128
 fri_folding_factors = [16, 16, 16, 8, 8]
 fri_early_stop_degree = 32
 grinding_query_phase = 0
+merkle_tree_arity = 3
+last_level_verification = 0
 
 [[circuits]]
 name = "MemAlignReadByte"
@@ -116,7 +130,7 @@ group = "basic"
 trace_length = 4194304
 rho = 0.5
 air_max_degree = 3
-num_columns = 16
+num_columns = [1, 10, 9, 6]
 opening_points = 3
 batch_size = 18
 power_batching = true
@@ -124,6 +138,8 @@ num_queries = 128
 fri_folding_factors = [16, 16, 16, 8, 8]
 fri_early_stop_degree = 32
 grinding_query_phase = 0
+merkle_tree_arity = 3
+last_level_verification = 0
 
 [[circuits]]
 name = "MemAlignWriteByte"
@@ -131,7 +147,7 @@ group = "basic"
 trace_length = 4194304
 rho = 0.5
 air_max_degree = 3
-num_columns = 21
+num_columns = [1, 14, 12, 6]
 opening_points = 3
 batch_size = 23
 power_batching = true
@@ -139,6 +155,8 @@ num_queries = 128
 fri_folding_factors = [16, 16, 16, 8, 8]
 fri_early_stop_degree = 32
 grinding_query_phase = 0
+merkle_tree_arity = 3
+last_level_verification = 0
 
 [[circuits]]
 name = "Arith"
@@ -146,7 +164,7 @@ group = "basic"
 trace_length = 2097152
 rho = 0.5
 air_max_degree = 3
-num_columns = 62
+num_columns = [1, 44, 45, 6]
 opening_points = 3
 batch_size = 64
 power_batching = true
@@ -154,6 +172,8 @@ num_queries = 128
 fri_folding_factors = [16, 16, 8, 8, 8]
 fri_early_stop_degree = 32
 grinding_query_phase = 0
+merkle_tree_arity = 3
+last_level_verification = 0
 
 [[circuits]]
 name = "Binary"
@@ -161,7 +181,7 @@ group = "basic"
 trace_length = 4194304
 rho = 0.5
 air_max_degree = 3
-num_columns = 47
+num_columns = [1, 39, 15, 6]
 opening_points = 3
 batch_size = 49
 power_batching = true
@@ -169,6 +189,8 @@ num_queries = 128
 fri_folding_factors = [16, 16, 16, 8, 8]
 fri_early_stop_degree = 32
 grinding_query_phase = 0
+merkle_tree_arity = 3
+last_level_verification = 0
 
 [[circuits]]
 name = "BinaryAdd"
@@ -176,7 +198,7 @@ group = "basic"
 trace_length = 4194304
 rho = 0.5
 air_max_degree = 3
-num_columns = 16
+num_columns = [1, 10, 9, 6]
 opening_points = 3
 batch_size = 18
 power_batching = true
@@ -184,6 +206,8 @@ num_queries = 128
 fri_folding_factors = [16, 16, 16, 8, 8]
 fri_early_stop_degree = 32
 grinding_query_phase = 0
+merkle_tree_arity = 3
+last_level_verification = 0
 
 [[circuits]]
 name = "BinaryExtension"
@@ -191,7 +215,7 @@ group = "basic"
 trace_length = 4194304
 rho = 0.5
 air_max_degree = 3
-num_columns = 38
+num_columns = [1, 29, 18, 6]
 opening_points = 3
 batch_size = 40
 power_batching = true
@@ -199,6 +223,8 @@ num_queries = 128
 fri_folding_factors = [16, 16, 16, 8, 8]
 fri_early_stop_degree = 32
 grinding_query_phase = 0
+merkle_tree_arity = 3
+last_level_verification = 0
 
 [[circuits]]
 name = "Add256"
@@ -206,7 +232,7 @@ group = "basic"
 trace_length = 1048576
 rho = 0.5
 air_max_degree = 3
-num_columns = 67
+num_columns = [1, 47, 51, 6]
 opening_points = 3
 batch_size = 69
 power_batching = true
@@ -214,6 +240,8 @@ num_queries = 128
 fri_folding_factors = [16, 16, 16, 16]
 fri_early_stop_degree = 32
 grinding_query_phase = 0
+merkle_tree_arity = 3
+last_level_verification = 0
 
 [[circuits]]
 name = "ArithEq"
@@ -221,7 +249,7 @@ group = "basic"
 trace_length = 1048576
 rho = 0.5
 air_max_degree = 3
-num_columns = 57
+num_columns = [2, 39, 40, 6]
 opening_points = 36
 batch_size = 434
 power_batching = true
@@ -229,6 +257,8 @@ num_queries = 128
 fri_folding_factors = [16, 16, 16, 16]
 fri_early_stop_degree = 32
 grinding_query_phase = 0
+merkle_tree_arity = 3
+last_level_verification = 0
 
 [[circuits]]
 name = "ArithEq384"
@@ -236,7 +266,7 @@ group = "basic"
 trace_length = 1048576
 rho = 0.5
 air_max_degree = 3
-num_columns = 51
+num_columns = [2, 33, 40, 6]
 opening_points = 54
 batch_size = 536
 power_batching = true
@@ -244,6 +274,8 @@ num_queries = 128
 fri_folding_factors = [16, 16, 16, 16]
 fri_early_stop_degree = 32
 grinding_query_phase = 0
+merkle_tree_arity = 3
+last_level_verification = 0
 
 [[circuits]]
 name = "Keccakf"
@@ -251,7 +283,7 @@ group = "basic"
 trace_length = 2097152
 rho = 0.5
 air_max_degree = 3
-num_columns = 71
+num_columns = [11, 47, 33, 6]
 opening_points = 71
 batch_size = 265
 power_batching = true
@@ -259,6 +291,8 @@ num_queries = 128
 fri_folding_factors = [16, 16, 8, 8, 8]
 fri_early_stop_degree = 32
 grinding_query_phase = 0
+merkle_tree_arity = 3
+last_level_verification = 0
 
 [[circuits]]
 name = "Sha256f"
@@ -266,7 +300,7 @@ group = "basic"
 trace_length = 262144
 rho = 0.5
 air_max_degree = 3
-num_columns = 113
+num_columns = [2, 102, 13, 6]
 opening_points = 87
 batch_size = 1265
 power_batching = true
@@ -274,6 +308,8 @@ num_queries = 128
 fri_folding_factors = [16, 16, 8, 8]
 fri_early_stop_degree = 32
 grinding_query_phase = 0
+merkle_tree_arity = 3
+last_level_verification = 0
 
 [[circuits]]
 name = "SpecifiedRanges"
@@ -281,7 +317,7 @@ group = "basic"
 trace_length = 1048576
 rho = 0.5
 air_max_degree = 3
-num_columns = 86
+num_columns = [34, 33, 51, 6]
 opening_points = 3
 batch_size = 88
 power_batching = true
@@ -289,6 +325,8 @@ num_queries = 128
 fri_folding_factors = [16, 16, 16, 16]
 fri_early_stop_degree = 32
 grinding_query_phase = 0
+merkle_tree_arity = 3
+last_level_verification = 0
 
 [[circuits]]
 name = "VirtualTable0"
@@ -296,7 +334,7 @@ group = "basic"
 trace_length = 1048576
 rho = 0.5
 air_max_degree = 3
-num_columns = 137
+num_columns = [109, 17, 27, 6]
 opening_points = 3
 batch_size = 139
 power_batching = true
@@ -304,6 +342,8 @@ num_queries = 128
 fri_folding_factors = [16, 16, 16, 16]
 fri_early_stop_degree = 32
 grinding_query_phase = 0
+merkle_tree_arity = 3
+last_level_verification = 0
 
 [[circuits]]
 name = "VirtualTable1"
@@ -311,7 +351,7 @@ group = "basic"
 trace_length = 1048576
 rho = 0.5
 air_max_degree = 3
-num_columns = 172
+num_columns = [145, 16, 27, 6]
 opening_points = 3
 batch_size = 174
 power_batching = true
@@ -319,6 +359,8 @@ num_queries = 128
 fri_folding_factors = [16, 16, 16, 16]
 fri_early_stop_degree = 32
 grinding_query_phase = 0
+merkle_tree_arity = 3
+last_level_verification = 0
 
 [[circuits]]
 name = "ArithEq-compressor"
@@ -326,7 +368,7 @@ group = "compression"
 trace_length = 262144
 rho = 0.25
 air_max_degree = 5
-num_columns = 119
+num_columns = [45, 36, 48, 12]
 opening_points = 4
 batch_size = 163
 power_batching = true
@@ -334,6 +376,8 @@ num_queries = 64
 fri_folding_factors = [16, 16, 16, 8]
 fri_early_stop_degree = 32
 grinding_query_phase = 0
+merkle_tree_arity = 3
+last_level_verification = 0
 
 [[circuits]]
 name = "ArithEq384-compressor"
@@ -341,7 +385,7 @@ group = "compression"
 trace_length = 262144
 rho = 0.25
 air_max_degree = 5
-num_columns = 119
+num_columns = [45, 36, 48, 12]
 opening_points = 4
 batch_size = 163
 power_batching = true
@@ -349,6 +393,8 @@ num_queries = 64
 fri_folding_factors = [16, 16, 16, 8]
 fri_early_stop_degree = 32
 grinding_query_phase = 0
+merkle_tree_arity = 3
+last_level_verification = 0
 
 [[circuits]]
 name = "Keccakf-compressor"
@@ -356,7 +402,7 @@ group = "compression"
 trace_length = 262144
 rho = 0.25
 air_max_degree = 5
-num_columns = 119
+num_columns = [45, 36, 48, 12]
 opening_points = 4
 batch_size = 163
 power_batching = true
@@ -364,6 +410,8 @@ num_queries = 64
 fri_folding_factors = [16, 16, 16, 8]
 fri_early_stop_degree = 32
 grinding_query_phase = 0
+merkle_tree_arity = 3
+last_level_verification = 0
 
 [[circuits]]
 name = "Sha256f-compressor"
@@ -371,7 +419,7 @@ group = "compression"
 trace_length = 524288
 rho = 0.25
 air_max_degree = 5
-num_columns = 119
+num_columns = [45, 36, 48, 12]
 opening_points = 4
 batch_size = 163
 power_batching = true
@@ -379,6 +427,8 @@ num_queries = 64
 fri_folding_factors = [16, 16, 16, 16]
 fri_early_stop_degree = 32
 grinding_query_phase = 0
+merkle_tree_arity = 3
+last_level_verification = 0
 
 [[circuits]]
 name = "VirtualTable0-compressor"
@@ -386,7 +436,7 @@ group = "compression"
 trace_length = 262144
 rho = 0.25
 air_max_degree = 5
-num_columns = 119
+num_columns = [45, 36, 48, 12]
 opening_points = 4
 batch_size = 163
 power_batching = true
@@ -394,6 +444,8 @@ num_queries = 64
 fri_folding_factors = [16, 16, 16, 8]
 fri_early_stop_degree = 32
 grinding_query_phase = 0
+merkle_tree_arity = 3
+last_level_verification = 0
 
 [[circuits]]
 name = "VirtualTable1-compressor"
@@ -401,7 +453,7 @@ group = "compression"
 trace_length = 262144
 rho = 0.25
 air_max_degree = 5
-num_columns = 119
+num_columns = [45, 36, 48, 12]
 opening_points = 4
 batch_size = 163
 power_batching = true
@@ -409,6 +461,8 @@ num_queries = 64
 fri_folding_factors = [16, 16, 16, 8]
 fri_early_stop_degree = 32
 grinding_query_phase = 0
+merkle_tree_arity = 3
+last_level_verification = 0
 
 [[circuits]]
 name = "Recursive2"
@@ -416,7 +470,7 @@ group = "aggregation"
 trace_length = 131072
 rho = 0.125
 air_max_degree = 8
-num_columns = 92
+num_columns = [45, 36, 12, 21]
 opening_points = 4
 batch_size = 136
 power_batching = true
@@ -424,6 +478,8 @@ num_queries = 43
 fri_folding_factors = [16, 16, 16, 8]
 fri_early_stop_degree = 32
 grinding_query_phase = 0
+merkle_tree_arity = 3
+last_level_verification = 0
 
 [[circuits]]
 name = "Final"
@@ -431,7 +487,7 @@ group = "final"
 trace_length = 65536
 rho = 0.0625
 air_max_degree = 8
-num_columns = 98
+num_columns = [45, 42, 12, 21]
 opening_points = 4
 batch_size = 142
 power_batching = true
@@ -439,3 +495,5 @@ num_queries = 32
 fri_folding_factors = [32, 32]
 fri_early_stop_degree = 1024
 grinding_query_phase = 0
+merkle_tree_arity = 3
+last_level_verification = 0


### PR DESCRIPTION
This PR modifies how proof size is calculated so that it matches Zisk proof size. (There is a small discrepancy still, I will check it out when I have some availability). 
It introduces two new parameters:
- Merkle tree arity: Currently, our trees are ternary merkle trees. We will move to a quaternary merkle tree in the next version to minimize the number of hashes the verifier needs to perform.
- Last level verification: The verifier does not compute the sibling path until the root but until certain level. The prover sends all the elements of that level, so the verifier can check that the value calculated is correct, and that with all those values it can obtain the root (which was added to the transcript). Currently it is set to zero, we will use it on the new version to minimize number of hashes the verifier needs to perform as well as proof size.

It also modifies num_columns to provide number of columns on each stage, since we have different merkle trees for different stages. This is backwards compatible with current solution for other zkvm