### PR TITLE
Correct grinding in fri.py

### DIFF
--- a/soundcalc/pcs/fri.py
+++ b/soundcalc/pcs/fri.py
@@ -204,9 +204,6 @@ class FRI(PCS):
             epsilon = regime.get_error_multilinear(rate, dimension, self.batch_size)
         else:
             epsilon = regime.get_error_linear(rate, dimension)
-            
-        # add grinding for batching within the commit phase
-        epsilon = apply_grinding(epsilon, self.grinding_commit_phase)
 
         return apply_grinding(epsilon, self.grinding_bits_batching)
 
@@ -224,7 +221,7 @@ class FRI(PCS):
 
         epsilon = regime.get_error_powers(rate, dimension, self.FRI_folding_factors[round])
 
-        return epsilon
+        return apply_grinding(epsilon, self.grinding_commit_phase)
 
     def _get_query_phase_error(self, regime: ProximityGapsRegime) -> float:
         """


### PR DESCRIPTION
While calculating the batching error we're inadvertently applying the grinding calculation twice to the same error bound, resulting in an inaccurate measurement. I do think it makes sense to have separate grinding for batch and commitment since the batch size for batch is usually much higher than for commitment so it'd make sense to do more grinding there.