### PR TITLE
Add Venus zkVM soundcalc configuration

### DIFF
--- a/reports/summary.md
+++ b/reports/summary.md
@@ -12,6 +12,7 @@ How to read this report:
 | [OpenVM](openvm.md) | 1.5.0 | **100** bits (UDR) | 8231 KiB | FRI | BabyBear⁴ | 3 | app |
 | [Pico](pico.md) | — | **53** bits (JBR) | 281 KiB | FRI | KoalaBear⁴ | 5 | riscv |
 | [SP1](sp1.md) | — | **98** bits (UDR) | 1001 KiB | Unknown | KoalaBear⁴ | 4 | wrap |
+| [Venus](venus.md) | 0.1.6 | **128** bits (JBR) | 313 KiB | FRI | Goldilocks³ | 44 | Dma |
 | [ZisK](zisk.md) | 0.16.0 | **128** bits (JBR) | 313 KiB | FRI | Goldilocks³ | 44 | Dma |
 
 ## Notes

--- a/reports/venus.md
+++ b/reports/venus.md
@@ -1,0 +1,1329 @@
+# 📊 Venus (v0.1.6)
+
+How to read this report:
+- Table rows correspond to security regimes
+- Table columns correspond to proof system components
+- Cells show bits of security per component
+- Proof size estimates are indicative (1 KiB = 1024 bytes)
+
+## zkVM Overview
+
+| Metric | Value | Relevant circuit | Notes |
+| --- | --- | --- | --- |
+| Final proof size (worst case) | **313 KiB** | [Final_Compressed](#final_compressed) | |
+| Final bits of security | **128 bits** | [Dma](#dma) | Regime: JBR |
+
+## Circuits
+
+- [Dma](#dma)
+- [DmaMemCpy](#dmamemcpy)
+- [DmaInputCpy](#dmainputcpy)
+- [Dma64Aligned](#dma64aligned)
+- [Dma64AlignedInputCpy](#dma64alignedinputcpy)
+- [Dma64AlignedMemSet](#dma64alignedmemset)
+- [Dma64AlignedMem](#dma64alignedmem)
+- [Dma64AlignedMemCpy](#dma64alignedmemcpy)
+- [DmaUnaligned](#dmaunaligned)
+- [DmaPrePost](#dmaprepost)
+- [DmaPrePostMemCpy](#dmaprepostmemcpy)
+- [DmaPrePostInputCpy](#dmaprepostinputcpy)
+- [Main](#main)
+- [Rom](#rom)
+- [Mem](#mem)
+- [RomData](#romdata)
+- [InputData](#inputdata)
+- [MemAlign](#memalign)
+- [MemAlignByte](#memalignbyte)
+- [MemAlignReadByte](#memalignreadbyte)
+- [MemAlignWriteByte](#memalignwritebyte)
+- [Arith](#arith)
+- [Binary](#binary)
+- [BinaryAdd](#binaryadd)
+- [BinaryExtension](#binaryextension)
+- [Add256](#add256)
+- [ArithEq](#aritheq)
+- [ArithEq384](#aritheq384)
+- [Keccakf](#keccakf)
+- [Sha256f](#sha256f)
+- [Poseidon2](#poseidon2)
+- [Blake2br](#blake2br)
+- [SpecifiedRanges](#specifiedranges)
+- [VirtualTable0](#virtualtable0)
+- [VirtualTable1](#virtualtable1)
+- [DmaPrePost-compressor](#dmaprepost-compressor)
+- [ArithEq-compressor](#aritheq-compressor)
+- [ArithEq384-compressor](#aritheq384-compressor)
+- [Keccakf-compressor](#keccakf-compressor)
+- [Sha256f-compressor](#sha256f-compressor)
+- [Blake2br-compressor](#blake2br-compressor)
+- [Recursive2](#recursive2)
+- [Final](#final)
+- [Final_Compressed](#final_compressed)
+
+## Dma
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 229
+- Grinding query phase (bits): 16
+- Field: Goldilocks³
+- Rate (ρ): 0.5
+- Trace length (H): $2^{21}$
+- FRI rounds: 6
+- FRI folding factors: [8, 8, 8, 8, 8, 4]
+- FRI early stop degree: 32
+- Number of constraints: 49
+- Batch size: 46
+- Batching: Powers
+- Lookup (logup): Lookup_gsum_[5000]
+- Lookup (logup): Lookup_gsum_[77]
+- Lookup (logup): Lookup_gsum_[8001]
+- Lookup (logup): Permutation_gsum_[10]
+- Lookup (logup): Permutation_gsum_[8000]
+- Lookup (logup): Range Check_gsum_[102]
+- Lookup (logup): Range Check_gsum_[103]
+- Lookup (logup): Range Check_gsum_[104]
+
+**Proof Size:** 748 KiB (expected) / 1142 KiB (worst case)
+
+| regime | total | Lookup_gsum_[5000] | Lookup_gsum_[77] | Lookup_gsum_[8001] | Permutation_gsum_[10] | Permutation_gsum_[8000] | Range Check_gsum_[102] | Range Check_gsum_[103] | Range Check_gsum_[104] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | commit round 6 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 111 | 166 | 169 | 168 | 168 | 166 | 170 | 169 | 169 | 186 | 168 | 166 | 172 | 175 | 178 | 181 | 184 | 187 | 111 |
+| JBR | 128 | 166 | 169 | 168 | 168 | 166 | 170 | 169 | 169 | 179 | 161 | 128 | 133 | 136 | 139 | 142 | 145 | 149 | 128 |
+
+
+## DmaMemCpy
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 229
+- Grinding query phase (bits): 16
+- Field: Goldilocks³
+- Rate (ρ): 0.5
+- Trace length (H): $2^{21}$
+- FRI rounds: 6
+- FRI folding factors: [8, 8, 8, 8, 8, 4]
+- FRI early stop degree: 32
+- Number of constraints: 22
+- Batch size: 33
+- Batching: Powers
+- Lookup (logup): Lookup_gsum_[5000]
+- Lookup (logup): Lookup_gsum_[77]
+- Lookup (logup): Lookup_gsum_[8001]
+- Lookup (logup): Permutation_gsum_[10]
+- Lookup (logup): Permutation_gsum_[8000]
+- Lookup (logup): Range Check_gsum_[102]
+- Lookup (logup): Range Check_gsum_[104]
+
+**Proof Size:** 679 KiB (expected) / 1072 KiB (worst case)
+
+| regime | total | Lookup_gsum_[5000] | Lookup_gsum_[77] | Lookup_gsum_[8001] | Permutation_gsum_[10] | Permutation_gsum_[8000] | Range Check_gsum_[102] | Range Check_gsum_[104] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | commit round 6 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 111 | 166 | 169 | 168 | 168 | 166 | 170 | 169 | 187 | 168 | 166 | 172 | 175 | 178 | 181 | 184 | 187 | 111 |
+| JBR | 128 | 166 | 169 | 168 | 168 | 166 | 170 | 169 | 180 | 161 | 128 | 133 | 136 | 139 | 142 | 145 | 148 | 128 |
+
+
+## DmaInputCpy
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 229
+- Grinding query phase (bits): 16
+- Field: Goldilocks³
+- Rate (ρ): 0.5
+- Trace length (H): $2^{21}$
+- FRI rounds: 6
+- FRI folding factors: [8, 8, 8, 8, 8, 4]
+- FRI early stop degree: 32
+- Number of constraints: 20
+- Batch size: 27
+- Batching: Powers
+- Lookup (logup): Lookup_gsum_[5000]
+- Lookup (logup): Lookup_gsum_[8001]
+- Lookup (logup): Permutation_gsum_[10]
+- Lookup (logup): Permutation_gsum_[8000]
+- Lookup (logup): Range Check_gsum_[102]
+- Lookup (logup): Range Check_gsum_[104]
+- Lookup (logup): Range Check_gsum_[105]
+
+**Proof Size:** 646 KiB (expected) / 1040 KiB (worst case)
+
+| regime | total | Lookup_gsum_[5000] | Lookup_gsum_[8001] | Permutation_gsum_[10] | Permutation_gsum_[8000] | Range Check_gsum_[102] | Range Check_gsum_[104] | Range Check_gsum_[105] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | commit round 6 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 111 | 166 | 168 | 168 | 166 | 170 | 170 | 170 | 187 | 168 | 167 | 172 | 175 | 178 | 181 | 184 | 187 | 111 |
+| JBR | 128 | 166 | 168 | 168 | 166 | 170 | 170 | 170 | 180 | 161 | 128 | 133 | 136 | 139 | 142 | 145 | 148 | 128 |
+
+
+## Dma64Aligned
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 230
+- Grinding query phase (bits): 16
+- Field: Goldilocks³
+- Rate (ρ): 0.5
+- Trace length (H): $2^{21}$
+- FRI rounds: 6
+- FRI folding factors: [8, 8, 8, 8, 8, 4]
+- FRI early stop degree: 32
+- Number of constraints: 88
+- Batch size: 62
+- Batching: Powers
+- Lookup (logup): Direct_gsum_[5000]
+- Lookup (logup): Direct_gsum_[8200]
+- Lookup (logup): Lookup_gsum_[5000]
+- Lookup (logup): Lookup_gsum_[88]
+- Lookup (logup): Permutation_gsum_[10]
+- Lookup (logup): Range Check_gsum_[102]
+- Lookup (logup): Range Check_gsum_[103]
+
+**Proof Size:** 838 KiB (expected) / 1233 KiB (worst case)
+
+| regime | total | Direct_gsum_[5000] | Direct_gsum_[8200] | Lookup_gsum_[5000] | Lookup_gsum_[88] | Permutation_gsum_[10] | Range Check_gsum_[102] | Range Check_gsum_[103] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | commit round 6 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 111 | 167 | 166 | 167 | 167 | 165 | 167 | 169 | 185 | 168 | 166 | 172 | 175 | 178 | 181 | 184 | 187 | 111 |
+| JBR | 128 | 167 | 166 | 167 | 167 | 165 | 167 | 169 | 178 | 162 | 128 | 134 | 137 | 140 | 143 | 146 | 149 | 128 |
+
+
+## Dma64AlignedInputCpy
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 229
+- Grinding query phase (bits): 16
+- Field: Goldilocks³
+- Rate (ρ): 0.5
+- Trace length (H): $2^{21}$
+- FRI rounds: 6
+- FRI folding factors: [8, 8, 8, 8, 8, 4]
+- FRI early stop degree: 32
+- Number of constraints: 52
+- Batch size: 44
+- Batching: Powers
+- Lookup (logup): Direct_gsum_[5000]
+- Lookup (logup): Direct_gsum_[8200]
+- Lookup (logup): Lookup_gsum_[5000]
+- Lookup (logup): Lookup_gsum_[88]
+- Lookup (logup): Permutation_gsum_[10]
+- Lookup (logup): Range Check_gsum_[102]
+- Lookup (logup): Range Check_gsum_[103]
+
+**Proof Size:** 738 KiB (expected) / 1131 KiB (worst case)
+
+| regime | total | Direct_gsum_[5000] | Direct_gsum_[8200] | Lookup_gsum_[5000] | Lookup_gsum_[88] | Permutation_gsum_[10] | Range Check_gsum_[102] | Range Check_gsum_[103] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | commit round 6 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 111 | 167 | 166 | 167 | 167 | 166 | 167 | 169 | 186 | 168 | 166 | 172 | 175 | 178 | 181 | 184 | 187 | 111 |
+| JBR | 128 | 167 | 166 | 167 | 167 | 166 | 167 | 169 | 179 | 161 | 128 | 133 | 136 | 139 | 142 | 145 | 149 | 128 |
+
+
+## Dma64AlignedMemSet
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 229
+- Grinding query phase (bits): 16
+- Field: Goldilocks³
+- Rate (ρ): 0.5
+- Trace length (H): $2^{21}$
+- FRI rounds: 6
+- FRI folding factors: [8, 8, 8, 8, 8, 4]
+- FRI early stop degree: 32
+- Number of constraints: 62
+- Batch size: 30
+- Batching: Powers
+- Lookup (logup): Direct_gsum_[5000]
+- Lookup (logup): Direct_gsum_[8200]
+- Lookup (logup): Lookup_gsum_[5000]
+- Lookup (logup): Permutation_gsum_[10]
+- Lookup (logup): Range Check_gsum_[103]
+
+**Proof Size:** 662 KiB (expected) / 1056 KiB (worst case)
+
+| regime | total | Direct_gsum_[5000] | Direct_gsum_[8200] | Lookup_gsum_[5000] | Permutation_gsum_[10] | Range Check_gsum_[103] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | commit round 6 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 111 | 167 | 166 | 167 | 165 | 169 | 186 | 168 | 167 | 172 | 175 | 178 | 181 | 184 | 187 | 111 |
+| JBR | 128 | 167 | 166 | 167 | 165 | 169 | 178 | 161 | 128 | 133 | 136 | 139 | 142 | 145 | 148 | 128 |
+
+
+## Dma64AlignedMem
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 229
+- Grinding query phase (bits): 16
+- Field: Goldilocks³
+- Rate (ρ): 0.5
+- Trace length (H): $2^{21}$
+- FRI rounds: 6
+- FRI folding factors: [8, 8, 8, 8, 8, 4]
+- FRI early stop degree: 32
+- Number of constraints: 81
+- Batch size: 46
+- Batching: Powers
+- Lookup (logup): Direct_gsum_[5000]
+- Lookup (logup): Direct_gsum_[8200]
+- Lookup (logup): Lookup_gsum_[5000]
+- Lookup (logup): Permutation_gsum_[10]
+- Lookup (logup): Range Check_gsum_[103]
+
+**Proof Size:** 748 KiB (expected) / 1142 KiB (worst case)
+
+| regime | total | Direct_gsum_[5000] | Direct_gsum_[8200] | Lookup_gsum_[5000] | Permutation_gsum_[10] | Range Check_gsum_[103] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | commit round 6 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 111 | 167 | 166 | 167 | 165 | 169 | 185 | 168 | 166 | 172 | 175 | 178 | 181 | 184 | 187 | 111 |
+| JBR | 128 | 167 | 166 | 167 | 165 | 169 | 178 | 161 | 128 | 133 | 136 | 139 | 142 | 145 | 149 | 128 |
+
+
+## Dma64AlignedMemCpy
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 229
+- Grinding query phase (bits): 16
+- Field: Goldilocks³
+- Rate (ρ): 0.5
+- Trace length (H): $2^{21}$
+- FRI rounds: 6
+- FRI folding factors: [8, 8, 8, 8, 8, 4]
+- FRI early stop degree: 32
+- Number of constraints: 69
+- Batch size: 52
+- Batching: Powers
+- Lookup (logup): Direct_gsum_[5000]
+- Lookup (logup): Direct_gsum_[8200]
+- Lookup (logup): Lookup_gsum_[5000]
+- Lookup (logup): Permutation_gsum_[10]
+- Lookup (logup): Range Check_gsum_[103]
+
+**Proof Size:** 781 KiB (expected) / 1174 KiB (worst case)
+
+| regime | total | Direct_gsum_[5000] | Direct_gsum_[8200] | Lookup_gsum_[5000] | Permutation_gsum_[10] | Range Check_gsum_[103] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | commit round 6 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 111 | 167 | 166 | 167 | 164 | 169 | 185 | 168 | 166 | 172 | 175 | 178 | 181 | 184 | 187 | 111 |
+| JBR | 128 | 167 | 166 | 167 | 164 | 169 | 178 | 161 | 128 | 133 | 136 | 139 | 142 | 145 | 149 | 128 |
+
+
+## DmaUnaligned
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 229
+- Grinding query phase (bits): 16
+- Field: Goldilocks³
+- Rate (ρ): 0.5
+- Trace length (H): $2^{21}$
+- FRI rounds: 6
+- FRI folding factors: [8, 8, 8, 8, 8, 4]
+- FRI early stop degree: 32
+- Number of constraints: 75
+- Batch size: 52
+- Batching: Powers
+- Lookup (logup): Direct_gsum_[5000]
+- Lookup (logup): Direct_gsum_[8201]
+- Lookup (logup): Lookup_gsum_[5000]
+- Lookup (logup): Lookup_gsum_[88]
+- Lookup (logup): Permutation_gsum_[10]
+- Lookup (logup): Range Check_gsum_[103]
+
+**Proof Size:** 781 KiB (expected) / 1174 KiB (worst case)
+
+| regime | total | Direct_gsum_[5000] | Direct_gsum_[8201] | Lookup_gsum_[5000] | Lookup_gsum_[88] | Permutation_gsum_[10] | Range Check_gsum_[103] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | commit round 6 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 111 | 167 | 165 | 167 | 167 | 166 | 169 | 185 | 168 | 166 | 172 | 175 | 178 | 181 | 184 | 187 | 111 |
+| JBR | 128 | 167 | 165 | 167 | 167 | 166 | 169 | 178 | 161 | 128 | 133 | 136 | 139 | 142 | 145 | 149 | 128 |
+
+
+## DmaPrePost
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 230
+- Grinding query phase (bits): 16
+- Field: Goldilocks³
+- Rate (ρ): 0.5
+- Trace length (H): $2^{21}$
+- FRI rounds: 6
+- FRI folding factors: [8, 8, 8, 8, 8, 4]
+- FRI early stop degree: 32
+- Number of constraints: 69
+- Batch size: 83
+- Batching: Powers
+- Lookup (logup): Lookup_gsum_[8002]
+- Lookup (logup): Lookup_gsum_[8003]
+- Lookup (logup): Lookup_gsum_[88]
+- Lookup (logup): Permutation_gsum_[10]
+- Lookup (logup): Permutation_gsum_[8000]
+
+**Proof Size:** 951 KiB (expected) / 1346 KiB (worst case)
+
+| regime | total | Lookup_gsum_[8002] | Lookup_gsum_[8003] | Lookup_gsum_[88] | Permutation_gsum_[10] | Permutation_gsum_[8000] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | commit round 6 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 111 | 168 | 169 | 166 | 166 | 167 | 185 | 168 | 165 | 172 | 175 | 178 | 181 | 184 | 187 | 111 |
+| JBR | 128 | 168 | 169 | 166 | 166 | 167 | 179 | 162 | 128 | 134 | 137 | 140 | 143 | 146 | 150 | 128 |
+
+
+## DmaPrePostMemCpy
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 230
+- Grinding query phase (bits): 16
+- Field: Goldilocks³
+- Rate (ρ): 0.5
+- Trace length (H): $2^{21}$
+- FRI rounds: 6
+- FRI folding factors: [8, 8, 8, 8, 8, 4]
+- FRI early stop degree: 32
+- Number of constraints: 38
+- Batch size: 70
+- Batching: Powers
+- Lookup (logup): Lookup_gsum_[8002]
+- Lookup (logup): Lookup_gsum_[88]
+- Lookup (logup): Permutation_gsum_[10]
+- Lookup (logup): Permutation_gsum_[8000]
+
+**Proof Size:** 881 KiB (expected) / 1276 KiB (worst case)
+
+| regime | total | Lookup_gsum_[8002] | Lookup_gsum_[88] | Permutation_gsum_[10] | Permutation_gsum_[8000] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | commit round 6 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 111 | 168 | 166 | 166 | 167 | 186 | 168 | 165 | 172 | 175 | 178 | 181 | 184 | 187 | 111 |
+| JBR | 128 | 168 | 166 | 166 | 167 | 179 | 162 | 128 | 134 | 137 | 140 | 143 | 146 | 149 | 128 |
+
+
+## DmaPrePostInputCpy
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 229
+- Grinding query phase (bits): 16
+- Field: Goldilocks³
+- Rate (ρ): 0.5
+- Trace length (H): $2^{21}$
+- FRI rounds: 6
+- FRI folding factors: [8, 8, 8, 8, 8, 4]
+- FRI early stop degree: 32
+- Number of constraints: 20
+- Batch size: 44
+- Batching: Powers
+- Lookup (logup): Lookup_gsum_[8002]
+- Lookup (logup): Lookup_gsum_[88]
+- Lookup (logup): Permutation_gsum_[10]
+- Lookup (logup): Permutation_gsum_[8000]
+
+**Proof Size:** 738 KiB (expected) / 1131 KiB (worst case)
+
+| regime | total | Lookup_gsum_[8002] | Lookup_gsum_[88] | Permutation_gsum_[10] | Permutation_gsum_[8000] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | commit round 6 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 111 | 168 | 166 | 167 | 167 | 187 | 168 | 166 | 172 | 175 | 178 | 181 | 184 | 187 | 111 |
+| JBR | 128 | 168 | 166 | 167 | 167 | 180 | 161 | 128 | 133 | 136 | 139 | 142 | 145 | 149 | 128 |
+
+
+## Main
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 230
+- Grinding query phase (bits): 16
+- Field: Goldilocks³
+- Rate (ρ): 0.5
+- Trace length (H): $2^{22}$
+- FRI rounds: 6
+- FRI folding factors: [8, 8, 8, 8, 8, 8]
+- FRI early stop degree: 32
+- Number of constraints: 144
+- Batch size: 61
+- Batching: Powers
+- Lookup (logup): Direct_gsum_[1000]
+- Lookup (logup): Lookup_gsum_[5000]
+- Lookup (logup): Lookup_gsum_[7890]
+- Lookup (logup): Permutation_gsum_[10]
+- Lookup (logup): Range Check_gsum_[102]
+- Lookup (logup): Range Check_gsum_[106]
+
+**Proof Size:** 890 KiB (expected) / 1292 KiB (worst case)
+
+| regime | total | Direct_gsum_[1000] | Lookup_gsum_[5000] | Lookup_gsum_[7890] | Permutation_gsum_[10] | Range Check_gsum_[102] | Range Check_gsum_[106] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | commit round 6 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 111 | 166 | 166 | 166 | 161 | 164 | 169 | 184 | 167 | 165 | 171 | 174 | 177 | 180 | 183 | 186 | 111 |
+| JBR | 128 | 166 | 166 | 166 | 161 | 164 | 169 | 178 | 161 | 128 | 134 | 137 | 140 | 143 | 146 | 149 | 128 |
+
+
+## Rom
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 221
+- Grinding query phase (bits): 20
+- Field: Goldilocks³
+- Rate (ρ): 0.5
+- Trace length (H): $2^{22}$
+- FRI rounds: 6
+- FRI folding factors: [8, 8, 8, 8, 8, 8]
+- FRI early stop degree: 32
+- Number of constraints: 3
+- Batch size: 18
+- Batching: Powers
+- Lookup (logup): Lookup_gsum_[7890]
+
+**Proof Size:** 635 KiB (expected) / 1019 KiB (worst case)
+
+| regime | total | Lookup_gsum_[7890] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | commit round 6 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 111 | 166 | 190 | 168 | 166 | 171 | 174 | 177 | 180 | 183 | 186 | 111 |
+| JBR | 128 | 166 | 183 | 161 | 128 | 132 | 135 | 138 | 141 | 144 | 147 | 128 |
+
+
+## Mem
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 230
+- Grinding query phase (bits): 16
+- Field: Goldilocks³
+- Rate (ρ): 0.5
+- Trace length (H): $2^{22}$
+- FRI rounds: 6
+- FRI folding factors: [8, 8, 8, 8, 8, 8]
+- FRI early stop degree: 32
+- Number of constraints: 34
+- Batch size: 29
+- Batching: Powers
+- Lookup (logup): Direct_gsum_[11]
+- Lookup (logup): Permutation_gsum_[10]
+- Lookup (logup): Range Check_gsum_[102]
+- Lookup (logup): Range Check_gsum_[103]
+- Lookup (logup): Range Check_gsum_[104]
+
+**Proof Size:** 718 KiB (expected) / 1120 KiB (worst case)
+
+| regime | total | Direct_gsum_[11] | Permutation_gsum_[10] | Range Check_gsum_[102] | Range Check_gsum_[103] | Range Check_gsum_[104] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | commit round 6 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 111 | 166 | 167 | 169 | 167 | 169 | 186 | 167 | 166 | 171 | 174 | 177 | 180 | 183 | 186 | 111 |
+| JBR | 128 | 166 | 167 | 169 | 167 | 169 | 179 | 161 | 128 | 133 | 136 | 139 | 142 | 145 | 148 | 128 |
+
+
+## RomData
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 229
+- Grinding query phase (bits): 16
+- Field: Goldilocks³
+- Rate (ρ): 0.5
+- Trace length (H): $2^{21}$
+- FRI rounds: 6
+- FRI folding factors: [8, 8, 8, 8, 8, 4]
+- FRI early stop degree: 32
+- Number of constraints: 23
+- Batch size: 19
+- Batching: Powers
+- Lookup (logup): Direct_gsum_[11]
+- Lookup (logup): Permutation_gsum_[10]
+- Lookup (logup): Range Check_gsum_[102]
+
+**Proof Size:** 603 KiB (expected) / 997 KiB (worst case)
+
+| regime | total | Direct_gsum_[11] | Permutation_gsum_[10] | Range Check_gsum_[102] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | commit round 6 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 111 | 167 | 168 | 169 | 187 | 168 | 167 | 172 | 175 | 178 | 181 | 184 | 187 | 111 |
+| JBR | 128 | 167 | 168 | 169 | 180 | 161 | 128 | 132 | 135 | 138 | 141 | 144 | 147 | 128 |
+
+
+## InputData
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 229
+- Grinding query phase (bits): 16
+- Field: Goldilocks³
+- Rate (ρ): 0.5
+- Trace length (H): $2^{21}$
+- FRI rounds: 6
+- FRI folding factors: [8, 8, 8, 8, 8, 4]
+- FRI early stop degree: 32
+- Number of constraints: 30
+- Batch size: 27
+- Batching: Powers
+- Lookup (logup): Direct_gsum_[11]
+- Lookup (logup): Permutation_gsum_[10]
+- Lookup (logup): Range Check_gsum_[102]
+- Lookup (logup): Range Check_gsum_[103]
+
+**Proof Size:** 646 KiB (expected) / 1040 KiB (worst case)
+
+| regime | total | Direct_gsum_[11] | Permutation_gsum_[10] | Range Check_gsum_[102] | Range Check_gsum_[103] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | commit round 6 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 111 | 167 | 168 | 170 | 167 | 187 | 168 | 167 | 172 | 175 | 178 | 181 | 184 | 187 | 111 |
+| JBR | 128 | 167 | 168 | 170 | 167 | 179 | 161 | 128 | 133 | 136 | 139 | 142 | 145 | 148 | 128 |
+
+
+## MemAlign
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 230
+- Grinding query phase (bits): 16
+- Field: Goldilocks³
+- Rate (ρ): 0.5
+- Trace length (H): $2^{21}$
+- FRI rounds: 6
+- FRI folding factors: [8, 8, 8, 8, 8, 4]
+- FRI early stop degree: 32
+- Number of constraints: 40
+- Batch size: 59
+- Batching: Powers
+- Lookup (logup): Lookup_gsum_[133]
+- Lookup (logup): Permutation_gsum_[10]
+- Lookup (logup): Range Check_gsum_[107]
+
+**Proof Size:** 821 KiB (expected) / 1217 KiB (worst case)
+
+| regime | total | Lookup_gsum_[133] | Permutation_gsum_[10] | Range Check_gsum_[107] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | commit round 6 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 111 | 168 | 168 | 167 | 186 | 168 | 166 | 172 | 175 | 178 | 181 | 184 | 187 | 111 |
+| JBR | 128 | 168 | 168 | 167 | 179 | 162 | 128 | 134 | 137 | 140 | 143 | 146 | 149 | 128 |
+
+
+## MemAlignByte
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 229
+- Grinding query phase (bits): 16
+- Field: Goldilocks³
+- Rate (ρ): 0.5
+- Trace length (H): $2^{22}$
+- FRI rounds: 6
+- FRI folding factors: [8, 8, 8, 8, 8, 8]
+- FRI early stop degree: 32
+- Number of constraints: 16
+- Batch size: 25
+- Batching: Powers
+- Lookup (logup): Direct_gsum_[10]
+- Lookup (logup): Lookup_gsum_[88]
+- Lookup (logup): Permutation_gsum_[10]
+- Lookup (logup): Range Check_gsum_[103]
+- Lookup (logup): Range Check_gsum_[107]
+
+**Proof Size:** 694 KiB (expected) / 1093 KiB (worst case)
+
+| regime | total | Direct_gsum_[10] | Lookup_gsum_[88] | Permutation_gsum_[10] | Range Check_gsum_[103] | Range Check_gsum_[107] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | commit round 6 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 111 | 166 | 168 | 165 | 169 | 169 | 187 | 167 | 166 | 171 | 174 | 177 | 180 | 183 | 186 | 111 |
+| JBR | 128 | 166 | 168 | 165 | 169 | 169 | 180 | 160 | 128 | 132 | 135 | 138 | 141 | 144 | 147 | 128 |
+
+
+## MemAlignReadByte
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 229
+- Grinding query phase (bits): 16
+- Field: Goldilocks³
+- Rate (ρ): 0.5
+- Trace length (H): $2^{22}$
+- FRI rounds: 6
+- FRI folding factors: [8, 8, 8, 8, 8, 8]
+- FRI early stop degree: 32
+- Number of constraints: 10
+- Batch size: 18
+- Batching: Powers
+- Lookup (logup): Direct_gsum_[10]
+- Lookup (logup): Lookup_gsum_[88]
+- Lookup (logup): Permutation_gsum_[10]
+- Lookup (logup): Range Check_gsum_[103]
+
+**Proof Size:** 656 KiB (expected) / 1056 KiB (worst case)
+
+| regime | total | Direct_gsum_[10] | Lookup_gsum_[88] | Permutation_gsum_[10] | Range Check_gsum_[103] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | commit round 6 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 111 | 166 | 168 | 166 | 169 | 188 | 167 | 166 | 171 | 174 | 177 | 180 | 183 | 186 | 111 |
+| JBR | 128 | 166 | 168 | 166 | 169 | 181 | 160 | 128 | 132 | 135 | 138 | 141 | 144 | 147 | 128 |
+
+
+## MemAlignWriteByte
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 229
+- Grinding query phase (bits): 16
+- Field: Goldilocks³
+- Rate (ρ): 0.5
+- Trace length (H): $2^{22}$
+- FRI rounds: 6
+- FRI folding factors: [8, 8, 8, 8, 8, 8]
+- FRI early stop degree: 32
+- Number of constraints: 15
+- Batch size: 23
+- Batching: Powers
+- Lookup (logup): Direct_gsum_[10]
+- Lookup (logup): Lookup_gsum_[88]
+- Lookup (logup): Permutation_gsum_[10]
+- Lookup (logup): Range Check_gsum_[103]
+- Lookup (logup): Range Check_gsum_[107]
+
+**Proof Size:** 683 KiB (expected) / 1082 KiB (worst case)
+
+| regime | total | Direct_gsum_[10] | Lookup_gsum_[88] | Permutation_gsum_[10] | Range Check_gsum_[103] | Range Check_gsum_[107] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | commit round 6 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 111 | 166 | 168 | 165 | 169 | 169 | 188 | 167 | 166 | 171 | 174 | 177 | 180 | 183 | 186 | 111 |
+| JBR | 128 | 166 | 168 | 165 | 169 | 169 | 181 | 160 | 128 | 132 | 135 | 138 | 141 | 144 | 147 | 128 |
+
+
+## Arith
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 230
+- Grinding query phase (bits): 16
+- Field: Goldilocks³
+- Rate (ρ): 0.5
+- Trace length (H): $2^{21}$
+- FRI rounds: 6
+- FRI folding factors: [8, 8, 8, 8, 8, 4]
+- FRI early stop degree: 32
+- Number of constraints: 65
+- Batch size: 64
+- Batching: Powers
+- Lookup (logup): Lookup_gsum_[330]
+- Lookup (logup): Lookup_gsum_[331]
+- Lookup (logup): Lookup_gsum_[5000]
+
+**Proof Size:** 848 KiB (expected) / 1244 KiB (worst case)
+
+| regime | total | Lookup_gsum_[330] | Lookup_gsum_[331] | Lookup_gsum_[5000] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | commit round 6 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 111 | 165 | 168 | 166 | 185 | 168 | 166 | 172 | 175 | 178 | 181 | 184 | 187 | 111 |
+| JBR | 128 | 165 | 168 | 166 | 179 | 162 | 128 | 134 | 137 | 140 | 143 | 146 | 149 | 128 |
+
+
+## Binary
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 230
+- Grinding query phase (bits): 16
+- Field: Goldilocks³
+- Rate (ρ): 0.5
+- Trace length (H): $2^{22}$
+- FRI rounds: 6
+- FRI folding factors: [8, 8, 8, 8, 8, 8]
+- FRI early stop degree: 32
+- Number of constraints: 14
+- Batch size: 49
+- Batching: Powers
+- Lookup (logup): Direct_gsum_[5000]
+- Lookup (logup): Lookup_gsum_[125]
+- Lookup (logup): Lookup_gsum_[5000]
+
+**Proof Size:** 826 KiB (expected) / 1227 KiB (worst case)
+
+| regime | total | Direct_gsum_[5000] | Lookup_gsum_[125] | Lookup_gsum_[5000] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | commit round 6 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 111 | 166 | 164 | 166 | 188 | 167 | 165 | 171 | 174 | 177 | 180 | 183 | 186 | 111 |
+| JBR | 128 | 166 | 164 | 166 | 181 | 161 | 128 | 133 | 136 | 139 | 142 | 145 | 148 | 128 |
+
+
+## BinaryAdd
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 229
+- Grinding query phase (bits): 16
+- Field: Goldilocks³
+- Rate (ρ): 0.5
+- Trace length (H): $2^{22}$
+- FRI rounds: 6
+- FRI folding factors: [8, 8, 8, 8, 8, 8]
+- FRI early stop degree: 32
+- Number of constraints: 9
+- Batch size: 18
+- Batching: Powers
+- Lookup (logup): Direct_gsum_[5000]
+- Lookup (logup): Lookup_gsum_[5000]
+- Lookup (logup): Range Check_gsum_[103]
+
+**Proof Size:** 656 KiB (expected) / 1056 KiB (worst case)
+
+| regime | total | Direct_gsum_[5000] | Lookup_gsum_[5000] | Range Check_gsum_[103] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | commit round 6 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 111 | 166 | 166 | 167 | 188 | 167 | 166 | 171 | 174 | 177 | 180 | 183 | 186 | 111 |
+| JBR | 128 | 166 | 166 | 167 | 181 | 160 | 128 | 132 | 135 | 138 | 141 | 144 | 147 | 128 |
+
+
+## BinaryExtension
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 230
+- Grinding query phase (bits): 16
+- Field: Goldilocks³
+- Rate (ρ): 0.5
+- Trace length (H): $2^{22}$
+- FRI rounds: 6
+- FRI folding factors: [8, 8, 8, 8, 8, 8]
+- FRI early stop degree: 32
+- Number of constraints: 8
+- Batch size: 40
+- Batching: Powers
+- Lookup (logup): Direct_gsum_[5000]
+- Lookup (logup): Lookup_gsum_[124]
+- Lookup (logup): Lookup_gsum_[5000]
+- Lookup (logup): Range Check_gsum_[102]
+
+**Proof Size:** 777 KiB (expected) / 1179 KiB (worst case)
+
+| regime | total | Direct_gsum_[5000] | Lookup_gsum_[124] | Lookup_gsum_[5000] | Range Check_gsum_[102] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | commit round 6 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 111 | 166 | 164 | 166 | 169 | 188 | 167 | 165 | 171 | 174 | 177 | 180 | 183 | 186 | 111 |
+| JBR | 128 | 166 | 164 | 166 | 169 | 182 | 161 | 128 | 133 | 136 | 139 | 142 | 145 | 148 | 128 |
+
+
+## Add256
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 229
+- Grinding query phase (bits): 16
+- Field: Goldilocks³
+- Rate (ρ): 0.5
+- Trace length (H): $2^{20}$
+- FRI rounds: 5
+- FRI folding factors: [8, 8, 8, 8, 8]
+- FRI early stop degree: 64
+- Number of constraints: 36
+- Batch size: 69
+- Batching: Powers
+- Lookup (logup): Lookup_gsum_[5000]
+- Lookup (logup): Permutation_gsum_[10]
+- Lookup (logup): Range Check_gsum_[103]
+
+**Proof Size:** 816 KiB (expected) / 1165 KiB (worst case)
+
+| regime | total | Lookup_gsum_[5000] | Permutation_gsum_[10] | Range Check_gsum_[103] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 111 | 168 | 165 | 167 | 186 | 169 | 166 | 173 | 176 | 179 | 182 | 185 | 111 |
+| JBR | 128 | 168 | 165 | 167 | 179 | 162 | 128 | 134 | 137 | 140 | 143 | 146 | 128 |
+
+
+## ArithEq
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 231
+- Grinding query phase (bits): 16
+- Field: Goldilocks³
+- Rate (ρ): 0.5
+- Trace length (H): $2^{20}$
+- FRI rounds: 5
+- FRI folding factors: [8, 8, 8, 8, 8]
+- FRI early stop degree: 64
+- Number of constraints: 103
+- Batch size: 470
+- Batching: Powers
+- Lookup (logup): Lookup_gsum_[5000]
+- Lookup (logup): Lookup_gsum_[5002]
+- Lookup (logup): Permutation_gsum_[10]
+- Lookup (logup): Range Check_gsum_[103, 104]
+- Lookup (logup): Range Check_gsum_[103]
+- Lookup (logup): Range Check_gsum_[108]
+
+**Proof Size:** 2994 KiB (expected) / 3346 KiB (worst case)
+
+| regime | total | Lookup_gsum_[5000] | Lookup_gsum_[5002] | Permutation_gsum_[10] | Range Check_gsum_[103, 104] | Range Check_gsum_[103] | Range Check_gsum_[108] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 111 | 168 | 169 | 168 | 170 | 169 | 169 | 185 | 169 | 164 | 173 | 176 | 179 | 182 | 185 | 111 |
+| JBR | 128 | 168 | 169 | 168 | 170 | 169 | 169 | 178 | 163 | 128 | 137 | 140 | 143 | 146 | 149 | 128 |
+
+
+## ArithEq384
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 232
+- Grinding query phase (bits): 16
+- Field: Goldilocks³
+- Rate (ρ): 0.5
+- Trace length (H): $2^{20}$
+- FRI rounds: 5
+- FRI folding factors: [8, 8, 8, 8, 8]
+- FRI early stop degree: 64
+- Number of constraints: 76
+- Batch size: 536
+- Batching: Powers
+- Lookup (logup): Lookup_gsum_[5000]
+- Lookup (logup): Lookup_gsum_[5002]
+- Lookup (logup): Permutation_gsum_[10]
+- Lookup (logup): Range Check_gsum_[103, 104]
+- Lookup (logup): Range Check_gsum_[103]
+- Lookup (logup): Range Check_gsum_[108]
+
+**Proof Size:** 3366 KiB (expected) / 3720 KiB (worst case)
+
+| regime | total | Lookup_gsum_[5000] | Lookup_gsum_[5002] | Permutation_gsum_[10] | Range Check_gsum_[103, 104] | Range Check_gsum_[103] | Range Check_gsum_[108] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 112 | 168 | 169 | 168 | 170 | 169 | 169 | 185 | 169 | 163 | 173 | 176 | 179 | 182 | 185 | 112 |
+| JBR | 128 | 168 | 169 | 168 | 170 | 169 | 169 | 179 | 163 | 128 | 137 | 140 | 143 | 146 | 149 | 128 |
+
+
+## Keccakf
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 217
+- Grinding query phase (bits): 23
+- Field: Goldilocks³
+- Rate (ρ): 0.5
+- Trace length (H): $2^{17}$
+- FRI rounds: 4
+- FRI folding factors: [8, 8, 8, 8]
+- FRI early stop degree: 64
+- Number of constraints: 2432
+- Batch size: 4065
+- Batching: Powers
+- Lookup (logup): Lookup_gsum_[126]
+- Lookup (logup): Lookup_gsum_[5000]
+- Lookup (logup): Permutation_gsum_[10]
+
+**Proof Size:** 20975 KiB (expected) / 21244 KiB (worst case)
+
+| regime | total | Lookup_gsum_[126] | Lookup_gsum_[5000] | Permutation_gsum_[10] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 113 | 163 | 171 | 167 | 180 | 172 | 164 | 176 | 179 | 182 | 185 | 113 |
+| JBR | 128 | 163 | 171 | 167 | 174 | 166 | 128 | 140 | 143 | 146 | 149 | 128 |
+
+
+## Sha256f
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 231
+- Grinding query phase (bits): 16
+- Field: Goldilocks³
+- Rate (ρ): 0.5
+- Trace length (H): $2^{18}$
+- FRI rounds: 5
+- FRI folding factors: [8, 8, 8, 8, 4]
+- FRI early stop degree: 32
+- Number of constraints: 115
+- Batch size: 1265
+- Batching: Powers
+- Lookup (logup): Lookup_gsum_[5000]
+- Lookup (logup): Permutation_gsum_[10]
+- Lookup (logup): Range Check_gsum_[109]
+
+**Proof Size:** 7215 KiB (expected) / 7549 KiB (worst case)
+
+| regime | total | Lookup_gsum_[5000] | Permutation_gsum_[10] | Range Check_gsum_[109] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 111 | 170 | 171 | 172 | 185 | 171 | 164 | 175 | 178 | 181 | 184 | 187 | 111 |
+| JBR | 128 | 170 | 171 | 172 | 178 | 165 | 128 | 138 | 141 | 144 | 147 | 150 | 128 |
+
+
+## Poseidon2
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 114
+- Grinding query phase (bits): 16
+- Field: Goldilocks³
+- Rate (ρ): 0.25
+- Trace length (H): $2^{17}$
+- FRI rounds: 5
+- FRI folding factors: [8, 8, 8, 8, 4]
+- FRI early stop degree: 32
+- Number of constraints: 85
+- Batch size: 182
+- Batching: Powers
+- Lookup (logup): Lookup_gsum_[5000]
+- Lookup (logup): Permutation_gsum_[10]
+
+**Proof Size:** 682 KiB (expected) / 832 KiB (worst case)
+
+| regime | total | Lookup_gsum_[5000] | Permutation_gsum_[10] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 93 | 171 | 170 | 185 | 172 | 166 | 174 | 177 | 180 | 183 | 186 | 93 |
+| JBR | 128 | 171 | 170 | 177 | 164 | 128 | 135 | 138 | 141 | 144 | 148 | 128 |
+
+
+## Blake2br
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 230
+- Grinding query phase (bits): 16
+- Field: Goldilocks³
+- Rate (ρ): 0.5
+- Trace length (H): $2^{18}$
+- FRI rounds: 5
+- FRI folding factors: [8, 8, 8, 8, 4]
+- FRI early stop degree: 32
+- Number of constraints: 189
+- Batch size: 651
+- Batching: Powers
+- Lookup (logup): Lookup_gsum_[5000]
+- Lookup (logup): Permutation_gsum_[10]
+- Lookup (logup): Permutation_gsum_[127]
+- Lookup (logup): Range Check_gsum_[103]
+
+**Proof Size:** 3874 KiB (expected) / 4207 KiB (worst case)
+
+| regime | total | Lookup_gsum_[5000] | Permutation_gsum_[10] | Permutation_gsum_[127] | Range Check_gsum_[103] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 111 | 170 | 169 | 171 | 170 | 184 | 171 | 165 | 175 | 178 | 181 | 184 | 187 | 111 |
+| JBR | 128 | 170 | 169 | 171 | 170 | 177 | 165 | 128 | 137 | 140 | 143 | 146 | 150 | 128 |
+
+
+## SpecifiedRanges
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 229
+- Grinding query phase (bits): 16
+- Field: Goldilocks³
+- Rate (ρ): 0.5
+- Trace length (H): $2^{20}$
+- FRI rounds: 5
+- FRI folding factors: [8, 8, 8, 8, 8]
+- FRI early stop degree: 64
+- Number of constraints: 16
+- Batch size: 107
+- Batching: Powers
+- Lookup (logup): Lookup_gsum_[102]
+- Lookup (logup): Lookup_gsum_[103, 104]
+- Lookup (logup): Lookup_gsum_[104, 105, 106, 107, 108]
+- Lookup (logup): Lookup_gsum_[104]
+- Lookup (logup): Lookup_gsum_[108, 109]
+- Lookup (logup): Lookup_gsum_[108]
+
+**Proof Size:** 1020 KiB (expected) / 1369 KiB (worst case)
+
+| regime | total | Lookup_gsum_[102] | Lookup_gsum_[103, 104] | Lookup_gsum_[104, 105, 106, 107, 108] | Lookup_gsum_[104] | Lookup_gsum_[108, 109] | Lookup_gsum_[108] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 111 | 171 | 171 | 171 | 171 | 171 | 171 | 187 | 169 | 166 | 173 | 176 | 179 | 182 | 185 | 111 |
+| JBR | 128 | 171 | 171 | 171 | 171 | 171 | 171 | 180 | 162 | 128 | 134 | 137 | 140 | 143 | 146 | 128 |
+
+
+## VirtualTable0
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 230
+- Grinding query phase (bits): 16
+- Field: Goldilocks³
+- Rate (ρ): 0.5
+- Trace length (H): $2^{21}$
+- FRI rounds: 6
+- FRI folding factors: [8, 8, 8, 8, 8, 4]
+- FRI early stop degree: 32
+- Number of constraints: 6
+- Batch size: 69
+- Batching: Powers
+- Lookup (logup): Lookup_gsum_[124, 8001]
+- Lookup (logup): Lookup_gsum_[125, 124]
+- Lookup (logup): Lookup_gsum_[125]
+- Lookup (logup): Lookup_gsum_[126, 331, 8002, 133, 125]
+- Lookup (logup): Lookup_gsum_[330]
+- Lookup (logup): Lookup_gsum_[5002, 88, 77, 8003, 126]
+
+**Proof Size:** 875 KiB (expected) / 1270 KiB (worst case)
+
+| regime | total | Lookup_gsum_[124, 8001] | Lookup_gsum_[125, 124] | Lookup_gsum_[125] | Lookup_gsum_[126, 331, 8002, 133, 125] | Lookup_gsum_[330] | Lookup_gsum_[5002, 88, 77, 8003, 126] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | commit round 6 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 111 | 168 | 168 | 168 | 168 | 169 | 168 | 189 | 168 | 165 | 172 | 175 | 178 | 181 | 184 | 187 | 111 |
+| JBR | 128 | 168 | 168 | 168 | 168 | 169 | 168 | 182 | 162 | 128 | 134 | 137 | 140 | 143 | 146 | 149 | 128 |
+
+
+## VirtualTable1
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 230
+- Grinding query phase (bits): 16
+- Field: Goldilocks³
+- Rate (ρ): 0.5
+- Trace length (H): $2^{21}$
+- FRI rounds: 6
+- FRI folding factors: [8, 8, 8, 8, 8, 4]
+- FRI early stop degree: 32
+- Number of constraints: 6
+- Batch size: 90
+- Batching: Powers
+- Lookup (logup): Lookup_gsum_[5000]
+
+**Proof Size:** 989 KiB (expected) / 1384 KiB (worst case)
+
+| regime | total | Lookup_gsum_[5000] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | commit round 6 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 111 | 167 | 189 | 168 | 165 | 172 | 175 | 178 | 181 | 184 | 187 | 111 |
+| JBR | 128 | 167 | 182 | 162 | 128 | 134 | 137 | 140 | 143 | 146 | 150 | 128 |
+
+
+## DmaPrePost-compressor
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 110
+- Grinding query phase (bits): 20
+- Field: Goldilocks³
+- Rate (ρ): 0.25
+- Trace length (H): $2^{18}$
+- FRI rounds: 5
+- FRI folding factors: [8, 8, 8, 8, 8]
+- FRI early stop degree: 32
+- Number of constraints: 179
+- Batch size: 198
+- Batching: Powers
+- Lookup (logup): Connection_gprod_[1]
+
+**Proof Size:** 726 KiB (expected) / 871 KiB (worst case)
+
+| regime | total | Connection_gprod_[1] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 94 | 166 | 184 | 171 | 165 | 173 | 176 | 179 | 182 | 185 | 94 |
+| JBR | 128 | 166 | 176 | 163 | 128 | 135 | 138 | 141 | 144 | 147 | 128 |
+
+
+## ArithEq-compressor
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 110
+- Grinding query phase (bits): 20
+- Field: Goldilocks³
+- Rate (ρ): 0.25
+- Trace length (H): $2^{18}$
+- FRI rounds: 5
+- FRI folding factors: [8, 8, 8, 8, 8]
+- FRI early stop degree: 32
+- Number of constraints: 179
+- Batch size: 198
+- Batching: Powers
+- Lookup (logup): Connection_gprod_[1]
+
+**Proof Size:** 726 KiB (expected) / 871 KiB (worst case)
+
+| regime | total | Connection_gprod_[1] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 94 | 166 | 184 | 171 | 165 | 173 | 176 | 179 | 182 | 185 | 94 |
+| JBR | 128 | 166 | 176 | 163 | 128 | 135 | 138 | 141 | 144 | 147 | 128 |
+
+
+## ArithEq384-compressor
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 110
+- Grinding query phase (bits): 20
+- Field: Goldilocks³
+- Rate (ρ): 0.25
+- Trace length (H): $2^{18}$
+- FRI rounds: 5
+- FRI folding factors: [8, 8, 8, 8, 8]
+- FRI early stop degree: 32
+- Number of constraints: 179
+- Batch size: 198
+- Batching: Powers
+- Lookup (logup): Connection_gprod_[1]
+
+**Proof Size:** 726 KiB (expected) / 871 KiB (worst case)
+
+| regime | total | Connection_gprod_[1] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 94 | 166 | 184 | 171 | 165 | 173 | 176 | 179 | 182 | 185 | 94 |
+| JBR | 128 | 166 | 176 | 163 | 128 | 135 | 138 | 141 | 144 | 147 | 128 |
+
+
+## Keccakf-compressor
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 110
+- Grinding query phase (bits): 20
+- Field: Goldilocks³
+- Rate (ρ): 0.25
+- Trace length (H): $2^{20}$
+- FRI rounds: 6
+- FRI folding factors: [8, 8, 8, 8, 8, 4]
+- FRI early stop degree: 32
+- Number of constraints: 179
+- Batch size: 198
+- Batching: Powers
+- Lookup (logup): Connection_gprod_[1]
+
+**Proof Size:** 771 KiB (expected) / 940 KiB (worst case)
+
+| regime | total | Connection_gprod_[1] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | commit round 6 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 94 | 164 | 184 | 169 | 163 | 171 | 174 | 177 | 180 | 183 | 186 | 94 |
+| JBR | 128 | 164 | 177 | 162 | 128 | 136 | 139 | 142 | 145 | 148 | 151 | 128 |
+
+
+## Sha256f-compressor
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 110
+- Grinding query phase (bits): 20
+- Field: Goldilocks³
+- Rate (ρ): 0.25
+- Trace length (H): $2^{19}$
+- FRI rounds: 5
+- FRI folding factors: [8, 8, 8, 8, 8]
+- FRI early stop degree: 64
+- Number of constraints: 179
+- Batch size: 198
+- Batching: Powers
+- Lookup (logup): Connection_gprod_[1]
+
+**Proof Size:** 743 KiB (expected) / 892 KiB (worst case)
+
+| regime | total | Connection_gprod_[1] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 94 | 165 | 184 | 170 | 164 | 172 | 175 | 178 | 181 | 184 | 94 |
+| JBR | 128 | 165 | 176 | 162 | 128 | 135 | 138 | 141 | 144 | 147 | 128 |
+
+
+## Blake2br-compressor
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 110
+- Grinding query phase (bits): 20
+- Field: Goldilocks³
+- Rate (ρ): 0.25
+- Trace length (H): $2^{18}$
+- FRI rounds: 5
+- FRI folding factors: [8, 8, 8, 8, 8]
+- FRI early stop degree: 32
+- Number of constraints: 179
+- Batch size: 198
+- Batching: Powers
+- Lookup (logup): Connection_gprod_[1]
+
+**Proof Size:** 726 KiB (expected) / 871 KiB (worst case)
+
+| regime | total | Connection_gprod_[1] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 94 | 166 | 184 | 171 | 165 | 173 | 176 | 179 | 182 | 185 | 94 |
+| JBR | 128 | 166 | 176 | 163 | 128 | 135 | 138 | 141 | 144 | 147 | 128 |
+
+
+## Recursive2
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 73
+- Grinding query phase (bits): 20
+- Field: Goldilocks³
+- Rate (ρ): 0.125
+- Trace length (H): $2^{17}$
+- FRI rounds: 5
+- FRI folding factors: [8, 8, 8, 8, 8]
+- FRI early stop degree: 32
+- Number of constraints: 158
+- Batch size: 145
+- Batching: Powers
+- Lookup (logup): Connection_gprod_[1]
+
+**Proof Size:** 398 KiB (expected) / 487 KiB (worst case)
+
+| regime | total | Connection_gprod_[1] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | commit round 5 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 80 | 168 | 184 | 171 | 166 | 173 | 176 | 179 | 182 | 185 | 80 |
+| JBR | 128 | 168 | 176 | 163 | 128 | 135 | 138 | 141 | 144 | 147 | 128 |
+
+
+## Final
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 43
+- Grinding query phase (bits): 22
+- Field: Goldilocks³
+- Rate (ρ): 0.03125
+- Trace length (H): $2^{16}$
+- FRI rounds: 4
+- FRI folding factors: [16, 16, 16, 16]
+- FRI early stop degree: 32
+- Number of constraints: 161
+- Batch size: 158
+- Batching: Powers
+- Lookup (logup): Connection_gprod_[1]
+
+**Proof Size:** 272 KiB (expected) / 311 KiB (worst case)
+
+| regime | total | Connection_gprod_[1] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | commit round 4 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 63 | 168 | 184 | 172 | 164 | 172 | 176 | 180 | 184 | 63 |
+| JBR | 128 | 168 | 175 | 163 | 128 | 136 | 140 | 144 | 148 | 128 |
+
+
+## Final_Compressed
+
+**Parameters:**
+- Polynomial commitment scheme: FRI
+- Hash size (bits): 256
+- Number of queries: 54
+- Grinding query phase (bits): 22
+- Field: Goldilocks³
+- Rate (ρ): 0.0625
+- Trace length (H): $2^{15}$
+- FRI rounds: 3
+- FRI folding factors: [8, 8, 8]
+- FRI early stop degree: 1024
+- Number of constraints: 158
+- Batch size: 145
+- Batching: Powers
+- Lookup (logup): Connection_gprod_[1]
+
+**Proof Size:** 269 KiB (expected) / 313 KiB (worst case)
+
+| regime | total | Connection_gprod_[1] | ALI | DEEP | batching | commit round 1 | commit round 2 | commit round 3 | query phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| UDR | 71 | 170 | 184 | 173 | 166 | 174 | 177 | 180 | 71 |
+| JBR | 128 | 170 | 175 | 164 | 129 | 136 | 139 | 142 | 128 |
+

--- a/soundcalc/main.py
+++ b/soundcalc/main.py
@@ -6,7 +6,7 @@ Loads zkVMs and produces soundness reports
 
 from __future__ import annotations
 
-from soundcalc.zkvms import risc0, miden, zisk, dummy_whir, pico, openvm, airbender, sp1
+from soundcalc.zkvms import risc0, miden, zisk, dummy_whir, pico, openvm, airbender, sp1, venus
 from soundcalc import report_cli, report_md
 
 # All zkVM loaders
@@ -19,6 +19,7 @@ _LOADERS = [
     ("OpenVM", openvm.load),
     ("Airbender", airbender.load),
     ("SP1", sp1.load),
+    ("Venus", venus.load),
 ]
 
 

--- a/soundcalc/zkvms/venus/__init__.py
+++ b/soundcalc/zkvms/venus/__init__.py
@@ -1,0 +1,6 @@
+from pathlib import Path
+
+from soundcalc.zkvms.zkvm import zkVM
+
+def load():
+    return zkVM.load_from_toml(Path(__file__).parent / "venus.toml")

--- a/soundcalc/zkvms/venus/venus.toml
+++ b/soundcalc/zkvms/venus/venus.toml
@@ -1,0 +1,2404 @@
+# Venus v0.1.6 soundcalc configuration — 44 circuits
+#
+# All parameters derived from Venus v0.1.6 proving key
+# (FRI, AIR, lookups, gap_to_radius, proof_size).
+# Cross-validated against ZisK upstream — identical soundness parameters.
+
+[[circuits]]
+name = "Dma"
+group = "basic"
+trace_length = 2097152
+rho = 0.5
+air_max_degree = 3
+num_columns_fixed = 1
+num_columns_witness = 55
+num_columns = 56
+num_constraints = 49
+opening_points = 3
+batch_size = 46
+power_batching = true
+num_queries = 229
+fri_folding_factors = [ 8, 8, 8, 8, 8, 4,]
+fri_early_stop_degree = 32
+grinding_query_phase = 16
+gap_to_radius = 0.005333333333333333
+proof_size = "1.62 MB"
+[[circuits.lookups]]
+name = "Lookup_gsum_[5000]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 2097152
+num_columns_S = 11
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Lookup_gsum_[77]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 2
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Lookup_gsum_[8001]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 7
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Permutation_gsum_[10]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 6
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Permutation_gsum_[8000]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 11
+num_lookups_M = 2
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Range Check_gsum_[102]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 1
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Range Check_gsum_[103]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 1
+num_lookups_M = 2
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Range Check_gsum_[104]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 1
+num_lookups_M = 2
+grinding_bits_lookup = 0
+
+
+[[circuits]]
+name = "DmaMemCpy"
+group = "basic"
+trace_length = 2097152
+rho = 0.5
+air_max_degree = 3
+num_columns_fixed = 1
+num_columns_witness = 40
+num_columns = 41
+num_constraints = 22
+opening_points = 3
+batch_size = 33
+power_batching = true
+num_queries = 229
+fri_folding_factors = [ 8, 8, 8, 8, 8, 4,]
+fri_early_stop_degree = 32
+grinding_query_phase = 16
+gap_to_radius = 0.005
+proof_size = "1.60 MB"
+[[circuits.lookups]]
+name = "Lookup_gsum_[5000]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 2097152
+num_columns_S = 11
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Lookup_gsum_[77]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 2
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Lookup_gsum_[8001]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 7
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Permutation_gsum_[10]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 6
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Permutation_gsum_[8000]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 11
+num_lookups_M = 2
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Range Check_gsum_[102]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 1
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Range Check_gsum_[104]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 1
+num_lookups_M = 2
+grinding_bits_lookup = 0
+
+
+[[circuits]]
+name = "DmaInputCpy"
+group = "basic"
+trace_length = 2097152
+rho = 0.5
+air_max_degree = 3
+num_columns_fixed = 1
+num_columns_witness = 34
+num_columns = 35
+num_constraints = 20
+opening_points = 3
+batch_size = 27
+power_batching = true
+num_queries = 229
+fri_folding_factors = [ 8, 8, 8, 8, 8, 4,]
+fri_early_stop_degree = 32
+grinding_query_phase = 16
+gap_to_radius = 0.004666666666666667
+proof_size = "1.59 MB"
+[[circuits.lookups]]
+name = "Lookup_gsum_[5000]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 2097152
+num_columns_S = 11
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Lookup_gsum_[8001]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 7
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Permutation_gsum_[10]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 6
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Permutation_gsum_[8000]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 11
+num_lookups_M = 2
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Range Check_gsum_[102]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 1
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Range Check_gsum_[104]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 1
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Range Check_gsum_[105]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 1
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+
+[[circuits]]
+name = "Dma64Aligned"
+group = "basic"
+trace_length = 2097152
+rho = 0.5
+air_max_degree = 3
+num_columns_fixed = 1
+num_columns_witness = 71
+num_columns = 72
+num_constraints = 88
+opening_points = 3
+batch_size = 62
+power_batching = true
+num_queries = 230
+fri_folding_factors = [ 8, 8, 8, 8, 8, 4,]
+fri_early_stop_degree = 32
+grinding_query_phase = 16
+gap_to_radius = 0.005666666666666667
+proof_size = "1.66 MB"
+[[circuits.lookups]]
+name = "Direct_gsum_[5000]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 11
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Direct_gsum_[8200]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 2097152
+num_columns_S = 10
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Lookup_gsum_[5000]"
+logup_type = "univariate"
+rows_L = 0
+rows_T = 2097152
+num_columns_S = 11
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Lookup_gsum_[88]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 2
+num_lookups_M = 4
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Permutation_gsum_[10]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 6
+num_lookups_M = 9
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Range Check_gsum_[102]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 1
+num_lookups_M = 8
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Range Check_gsum_[103]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 1
+num_lookups_M = 2
+grinding_bits_lookup = 0
+
+
+[[circuits]]
+name = "Dma64AlignedInputCpy"
+group = "basic"
+trace_length = 2097152
+rho = 0.5
+air_max_degree = 3
+num_columns_fixed = 1
+num_columns_witness = 52
+num_columns = 53
+num_constraints = 52
+opening_points = 3
+batch_size = 44
+power_batching = true
+num_queries = 229
+fri_folding_factors = [ 8, 8, 8, 8, 8, 4,]
+fri_early_stop_degree = 32
+grinding_query_phase = 16
+gap_to_radius = 0.005333333333333333
+proof_size = "1.62 MB"
+[[circuits.lookups]]
+name = "Direct_gsum_[5000]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 11
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Direct_gsum_[8200]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 2097152
+num_columns_S = 10
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Lookup_gsum_[5000]"
+logup_type = "univariate"
+rows_L = 0
+rows_T = 2097152
+num_columns_S = 11
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Lookup_gsum_[88]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 2
+num_lookups_M = 4
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Permutation_gsum_[10]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 6
+num_lookups_M = 4
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Range Check_gsum_[102]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 1
+num_lookups_M = 8
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Range Check_gsum_[103]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 1
+num_lookups_M = 2
+grinding_bits_lookup = 0
+
+
+[[circuits]]
+name = "Dma64AlignedMemSet"
+group = "basic"
+trace_length = 2097152
+rho = 0.5
+air_max_degree = 3
+num_columns_fixed = 1
+num_columns_witness = 29
+num_columns = 30
+num_constraints = 62
+opening_points = 3
+batch_size = 30
+power_batching = true
+num_queries = 229
+fri_folding_factors = [ 8, 8, 8, 8, 8, 4,]
+fri_early_stop_degree = 32
+grinding_query_phase = 16
+gap_to_radius = 0.005
+proof_size = "1.58 MB"
+[[circuits.lookups]]
+name = "Direct_gsum_[5000]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 11
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Direct_gsum_[8200]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 2097152
+num_columns_S = 10
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Lookup_gsum_[5000]"
+logup_type = "univariate"
+rows_L = 0
+rows_T = 2097152
+num_columns_S = 11
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Permutation_gsum_[10]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 6
+num_lookups_M = 8
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Range Check_gsum_[103]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 1
+num_lookups_M = 2
+grinding_bits_lookup = 0
+
+
+[[circuits]]
+name = "Dma64AlignedMem"
+group = "basic"
+trace_length = 2097152
+rho = 0.5
+air_max_degree = 3
+num_columns_fixed = 1
+num_columns_witness = 44
+num_columns = 45
+num_constraints = 81
+opening_points = 3
+batch_size = 46
+power_batching = true
+num_queries = 229
+fri_folding_factors = [ 8, 8, 8, 8, 8, 4,]
+fri_early_stop_degree = 32
+grinding_query_phase = 16
+gap_to_radius = 0.005333333333333333
+proof_size = "1.61 MB"
+[[circuits.lookups]]
+name = "Direct_gsum_[5000]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 11
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Direct_gsum_[8200]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 2097152
+num_columns_S = 10
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Lookup_gsum_[5000]"
+logup_type = "univariate"
+rows_L = 0
+rows_T = 2097152
+num_columns_S = 11
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Permutation_gsum_[10]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 6
+num_lookups_M = 9
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Range Check_gsum_[103]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 1
+num_lookups_M = 2
+grinding_bits_lookup = 0
+
+
+[[circuits]]
+name = "Dma64AlignedMemCpy"
+group = "basic"
+trace_length = 2097152
+rho = 0.5
+air_max_degree = 3
+num_columns_fixed = 1
+num_columns_witness = 61
+num_columns = 62
+num_constraints = 69
+opening_points = 3
+batch_size = 52
+power_batching = true
+num_queries = 229
+fri_folding_factors = [ 8, 8, 8, 8, 8, 4,]
+fri_early_stop_degree = 32
+grinding_query_phase = 16
+gap_to_radius = 0.005333333333333333
+proof_size = "1.64 MB"
+[[circuits.lookups]]
+name = "Direct_gsum_[5000]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 11
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Direct_gsum_[8200]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 2097152
+num_columns_S = 10
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Lookup_gsum_[5000]"
+logup_type = "univariate"
+rows_L = 0
+rows_T = 2097152
+num_columns_S = 11
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Permutation_gsum_[10]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 6
+num_lookups_M = 17
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Range Check_gsum_[103]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 1
+num_lookups_M = 2
+grinding_bits_lookup = 0
+
+
+[[circuits]]
+name = "DmaUnaligned"
+group = "basic"
+trace_length = 2097152
+rho = 0.5
+air_max_degree = 3
+num_columns_fixed = 1
+num_columns_witness = 36
+num_columns = 37
+num_constraints = 75
+opening_points = 3
+batch_size = 52
+power_batching = true
+num_queries = 229
+fri_folding_factors = [ 8, 8, 8, 8, 8, 4,]
+fri_early_stop_degree = 32
+grinding_query_phase = 16
+gap_to_radius = 0.005333333333333333
+proof_size = "1.59 MB"
+[[circuits.lookups]]
+name = "Direct_gsum_[5000]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 11
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Direct_gsum_[8201]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 2097152
+num_columns_S = 18
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Lookup_gsum_[5000]"
+logup_type = "univariate"
+rows_L = 0
+rows_T = 2097152
+num_columns_S = 11
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Lookup_gsum_[88]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 2
+num_lookups_M = 4
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Permutation_gsum_[10]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 2097152
+num_columns_S = 6
+num_lookups_M = 2
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Range Check_gsum_[103]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 1
+num_lookups_M = 2
+grinding_bits_lookup = 0
+
+
+[[circuits]]
+name = "DmaPrePost"
+group = "basic"
+trace_length = 2097152
+rho = 0.5
+air_max_degree = 3
+num_columns_fixed = 1
+num_columns_witness = 98
+num_columns = 99
+num_constraints = 69
+opening_points = 3
+batch_size = 83
+power_batching = true
+num_queries = 230
+fri_folding_factors = [ 8, 8, 8, 8, 8, 4,]
+fri_early_stop_degree = 32
+grinding_query_phase = 16
+gap_to_radius = 0.005999999999999999
+proof_size = "1.71 MB"
+[[circuits.lookups]]
+name = "Lookup_gsum_[8002]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 6
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Lookup_gsum_[8003]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 3
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Lookup_gsum_[88]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 2
+num_lookups_M = 12
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Permutation_gsum_[10]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 6
+num_lookups_M = 4
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Permutation_gsum_[8000]"
+logup_type = "univariate"
+rows_L = 0
+rows_T = 2097152
+num_columns_S = 11
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+
+[[circuits]]
+name = "DmaPrePostMemCpy"
+group = "basic"
+trace_length = 2097152
+rho = 0.5
+air_max_degree = 3
+num_columns_fixed = 1
+num_columns_witness = 85
+num_columns = 86
+num_constraints = 38
+opening_points = 3
+batch_size = 70
+power_batching = true
+num_queries = 230
+fri_folding_factors = [ 8, 8, 8, 8, 8, 4,]
+fri_early_stop_degree = 32
+grinding_query_phase = 16
+gap_to_radius = 0.005666666666666667
+proof_size = "1.69 MB"
+[[circuits.lookups]]
+name = "Lookup_gsum_[8002]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 6
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Lookup_gsum_[88]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 2
+num_lookups_M = 12
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Permutation_gsum_[10]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 6
+num_lookups_M = 4
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Permutation_gsum_[8000]"
+logup_type = "univariate"
+rows_L = 0
+rows_T = 2097152
+num_columns_S = 11
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+
+[[circuits]]
+name = "DmaPrePostInputCpy"
+group = "basic"
+trace_length = 2097152
+rho = 0.5
+air_max_degree = 3
+num_columns_fixed = 1
+num_columns_witness = 53
+num_columns = 54
+num_constraints = 20
+opening_points = 3
+batch_size = 44
+power_batching = true
+num_queries = 229
+fri_folding_factors = [ 8, 8, 8, 8, 8, 4,]
+fri_early_stop_degree = 32
+grinding_query_phase = 16
+gap_to_radius = 0.005333333333333333
+proof_size = "1.62 MB"
+[[circuits.lookups]]
+name = "Lookup_gsum_[8002]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 6
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Lookup_gsum_[88]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 2
+num_lookups_M = 8
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Permutation_gsum_[10]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 6
+num_lookups_M = 2
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Permutation_gsum_[8000]"
+logup_type = "univariate"
+rows_L = 0
+rows_T = 2097152
+num_columns_S = 11
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+
+[[circuits]]
+name = "Main"
+group = "basic"
+trace_length = 4194304
+rho = 0.5
+air_max_degree = 3
+num_columns_fixed = 3
+num_columns_witness = 62
+num_columns = 65
+num_constraints = 144
+opening_points = 3
+batch_size = 61
+power_batching = true
+num_queries = 230
+fri_folding_factors = [ 8, 8, 8, 8, 8, 8,]
+fri_early_stop_degree = 32
+grinding_query_phase = 16
+gap_to_radius = 0.006333333333333333
+proof_size = "1.80 MB"
+[[circuits.lookups]]
+name = "Direct_gsum_[1000]"
+logup_type = "univariate"
+rows_L = 4194304
+rows_T = 4194304
+num_columns_S = 5
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Lookup_gsum_[5000]"
+logup_type = "univariate"
+rows_L = 4194304
+rows_T = 0
+num_columns_S = 11
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Lookup_gsum_[7890]"
+logup_type = "univariate"
+rows_L = 4194304
+rows_T = 0
+num_columns_S = 11
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Permutation_gsum_[10]"
+logup_type = "univariate"
+rows_L = 4194304
+rows_T = 4194304
+num_columns_S = 6
+num_lookups_M = 34
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Range Check_gsum_[102]"
+logup_type = "univariate"
+rows_L = 4194304
+rows_T = 0
+num_columns_S = 1
+num_lookups_M = 34
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Range Check_gsum_[106]"
+logup_type = "univariate"
+rows_L = 4194304
+rows_T = 0
+num_columns_S = 1
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+
+[[circuits]]
+name = "Rom"
+group = "basic"
+trace_length = 4194304
+rho = 0.5
+air_max_degree = 2
+num_columns_fixed = 1
+num_columns_witness = 18
+num_columns = 19
+num_constraints = 3
+opening_points = 3
+batch_size = 18
+power_batching = true
+num_queries = 221
+fri_folding_factors = [ 8, 8, 8, 8, 8, 8,]
+fri_early_stop_degree = 32
+grinding_query_phase = 20
+gap_to_radius = 0.005
+proof_size = "1.84 MB"
+[[circuits.lookups]]
+name = "Lookup_gsum_[7890]"
+logup_type = "univariate"
+rows_L = 0
+rows_T = 4194304
+num_columns_S = 11
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+
+[[circuits]]
+name = "Mem"
+group = "basic"
+trace_length = 4194304
+rho = 0.5
+air_max_degree = 3
+num_columns_fixed = 2
+num_columns_witness = 22
+num_columns = 24
+num_constraints = 34
+opening_points = 3
+batch_size = 29
+power_batching = true
+num_queries = 230
+fri_folding_factors = [ 8, 8, 8, 8, 8, 8,]
+fri_early_stop_degree = 32
+grinding_query_phase = 16
+gap_to_radius = 0.005666666666666667
+proof_size = "1.72 MB"
+[[circuits.lookups]]
+name = "Direct_gsum_[11]"
+logup_type = "univariate"
+rows_L = 4194304
+rows_T = 4194304
+num_columns_S = 6
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Permutation_gsum_[10]"
+logup_type = "univariate"
+rows_L = 0
+rows_T = 4194304
+num_columns_S = 6
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Range Check_gsum_[102]"
+logup_type = "univariate"
+rows_L = 4194304
+rows_T = 0
+num_columns_S = 1
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Range Check_gsum_[103]"
+logup_type = "univariate"
+rows_L = 4194304
+rows_T = 0
+num_columns_S = 1
+num_lookups_M = 5
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Range Check_gsum_[104]"
+logup_type = "univariate"
+rows_L = 4194304
+rows_T = 0
+num_columns_S = 1
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+
+[[circuits]]
+name = "RomData"
+group = "basic"
+trace_length = 2097152
+rho = 0.5
+air_max_degree = 3
+num_columns_fixed = 2
+num_columns_witness = 15
+num_columns = 17
+num_constraints = 23
+opening_points = 3
+batch_size = 19
+power_batching = true
+num_queries = 229
+fri_folding_factors = [ 8, 8, 8, 8, 8, 4,]
+fri_early_stop_degree = 32
+grinding_query_phase = 16
+gap_to_radius = 0.004333333333333333
+proof_size = "1.56 MB"
+[[circuits.lookups]]
+name = "Direct_gsum_[11]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 2097152
+num_columns_S = 6
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Permutation_gsum_[10]"
+logup_type = "univariate"
+rows_L = 0
+rows_T = 2097152
+num_columns_S = 6
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Range Check_gsum_[102]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 1
+num_lookups_M = 3
+grinding_bits_lookup = 0
+
+
+[[circuits]]
+name = "InputData"
+group = "basic"
+trace_length = 2097152
+rho = 0.5
+air_max_degree = 3
+num_columns_fixed = 2
+num_columns_witness = 23
+num_columns = 25
+num_constraints = 30
+opening_points = 3
+batch_size = 27
+power_batching = true
+num_queries = 229
+fri_folding_factors = [ 8, 8, 8, 8, 8, 4,]
+fri_early_stop_degree = 32
+grinding_query_phase = 16
+gap_to_radius = 0.004666666666666667
+proof_size = "1.57 MB"
+[[circuits.lookups]]
+name = "Direct_gsum_[11]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 2097152
+num_columns_S = 6
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Permutation_gsum_[10]"
+logup_type = "univariate"
+rows_L = 0
+rows_T = 2097152
+num_columns_S = 6
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Range Check_gsum_[102]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 1
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Range Check_gsum_[103]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 1
+num_lookups_M = 8
+grinding_bits_lookup = 0
+
+
+[[circuits]]
+name = "MemAlign"
+group = "basic"
+trace_length = 2097152
+rho = 0.5
+air_max_degree = 3
+num_columns_fixed = 2
+num_columns_witness = 47
+num_columns = 49
+num_constraints = 40
+opening_points = 3
+batch_size = 59
+power_batching = true
+num_queries = 230
+fri_folding_factors = [ 8, 8, 8, 8, 8, 4,]
+fri_early_stop_degree = 32
+grinding_query_phase = 16
+gap_to_radius = 0.005666666666666667
+proof_size = "1.62 MB"
+[[circuits.lookups]]
+name = "Lookup_gsum_[133]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 6
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Permutation_gsum_[10]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 6
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Range Check_gsum_[107]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 1
+num_lookups_M = 8
+grinding_bits_lookup = 0
+
+
+[[circuits]]
+name = "MemAlignByte"
+group = "basic"
+trace_length = 4194304
+rho = 0.5
+air_max_degree = 3
+num_columns_fixed = 1
+num_columns_witness = 28
+num_columns = 29
+num_constraints = 16
+opening_points = 3
+batch_size = 25
+power_batching = true
+num_queries = 229
+fri_folding_factors = [ 8, 8, 8, 8, 8, 8,]
+fri_early_stop_degree = 32
+grinding_query_phase = 16
+gap_to_radius = 0.005333333333333333
+proof_size = "1.72 MB"
+[[circuits.lookups]]
+name = "Direct_gsum_[10]"
+logup_type = "univariate"
+rows_L = 4194304
+rows_T = 4194304
+num_columns_S = 6
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Lookup_gsum_[88]"
+logup_type = "univariate"
+rows_L = 4194304
+rows_T = 0
+num_columns_S = 2
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Permutation_gsum_[10]"
+logup_type = "univariate"
+rows_L = 4194304
+rows_T = 4194304
+num_columns_S = 6
+num_lookups_M = 2
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Range Check_gsum_[103]"
+logup_type = "univariate"
+rows_L = 4194304
+rows_T = 0
+num_columns_S = 1
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Range Check_gsum_[107]"
+logup_type = "univariate"
+rows_L = 4194304
+rows_T = 0
+num_columns_S = 1
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+
+[[circuits]]
+name = "MemAlignReadByte"
+group = "basic"
+trace_length = 4194304
+rho = 0.5
+air_max_degree = 3
+num_columns_fixed = 1
+num_columns_witness = 19
+num_columns = 20
+num_constraints = 10
+opening_points = 3
+batch_size = 18
+power_batching = true
+num_queries = 229
+fri_folding_factors = [ 8, 8, 8, 8, 8, 8,]
+fri_early_stop_degree = 32
+grinding_query_phase = 16
+gap_to_radius = 0.005
+proof_size = "1.71 MB"
+[[circuits.lookups]]
+name = "Direct_gsum_[10]"
+logup_type = "univariate"
+rows_L = 4194304
+rows_T = 4194304
+num_columns_S = 6
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Lookup_gsum_[88]"
+logup_type = "univariate"
+rows_L = 4194304
+rows_T = 0
+num_columns_S = 2
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Permutation_gsum_[10]"
+logup_type = "univariate"
+rows_L = 4194304
+rows_T = 4194304
+num_columns_S = 6
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Range Check_gsum_[103]"
+logup_type = "univariate"
+rows_L = 4194304
+rows_T = 0
+num_columns_S = 1
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+
+[[circuits]]
+name = "MemAlignWriteByte"
+group = "basic"
+trace_length = 4194304
+rho = 0.5
+air_max_degree = 3
+num_columns_fixed = 1
+num_columns_witness = 26
+num_columns = 27
+num_constraints = 15
+opening_points = 3
+batch_size = 23
+power_batching = true
+num_queries = 229
+fri_folding_factors = [ 8, 8, 8, 8, 8, 8,]
+fri_early_stop_degree = 32
+grinding_query_phase = 16
+gap_to_radius = 0.005333333333333333
+proof_size = "1.72 MB"
+[[circuits.lookups]]
+name = "Direct_gsum_[10]"
+logup_type = "univariate"
+rows_L = 4194304
+rows_T = 4194304
+num_columns_S = 6
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Lookup_gsum_[88]"
+logup_type = "univariate"
+rows_L = 4194304
+rows_T = 0
+num_columns_S = 2
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Permutation_gsum_[10]"
+logup_type = "univariate"
+rows_L = 4194304
+rows_T = 4194304
+num_columns_S = 6
+num_lookups_M = 2
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Range Check_gsum_[103]"
+logup_type = "univariate"
+rows_L = 4194304
+rows_T = 0
+num_columns_S = 1
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Range Check_gsum_[107]"
+logup_type = "univariate"
+rows_L = 4194304
+rows_T = 0
+num_columns_S = 1
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+
+[[circuits]]
+name = "Arith"
+group = "basic"
+trace_length = 2097152
+rho = 0.5
+air_max_degree = 3
+num_columns_fixed = 1
+num_columns_witness = 89
+num_columns = 90
+num_constraints = 65
+opening_points = 3
+batch_size = 64
+power_batching = true
+num_queries = 230
+fri_folding_factors = [ 8, 8, 8, 8, 8, 4,]
+fri_early_stop_degree = 32
+grinding_query_phase = 16
+gap_to_radius = 0.005666666666666667
+proof_size = "1.69 MB"
+[[circuits.lookups]]
+name = "Lookup_gsum_[330]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 2
+num_lookups_M = 23
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Lookup_gsum_[331]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 0
+num_columns_S = 4
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Lookup_gsum_[5000]"
+logup_type = "univariate"
+rows_L = 2097152
+rows_T = 2097152
+num_columns_S = 11
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+
+[[circuits]]
+name = "Binary"
+group = "basic"
+trace_length = 4194304
+rho = 0.5
+air_max_degree = 3
+num_columns_fixed = 1
+num_columns_witness = 54
+num_columns = 55
+num_constraints = 14
+opening_points = 3
+batch_size = 49
+power_batching = true
+num_queries = 230
+fri_folding_factors = [ 8, 8, 8, 8, 8, 8,]
+fri_early_stop_degree = 32
+grinding_query_phase = 16
+gap_to_radius = 0.005999999999999999
+proof_size = "1.78 MB"
+[[circuits.lookups]]
+name = "Direct_gsum_[5000]"
+logup_type = "univariate"
+rows_L = 4194304
+rows_T = 0
+num_columns_S = 11
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Lookup_gsum_[125]"
+logup_type = "univariate"
+rows_L = 4194304
+rows_T = 0
+num_columns_S = 7
+num_lookups_M = 8
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Lookup_gsum_[5000]"
+logup_type = "univariate"
+rows_L = 0
+rows_T = 4194304
+num_columns_S = 11
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+
+[[circuits]]
+name = "BinaryAdd"
+group = "basic"
+trace_length = 4194304
+rho = 0.5
+air_max_degree = 3
+num_columns_fixed = 1
+num_columns_witness = 19
+num_columns = 20
+num_constraints = 9
+opening_points = 3
+batch_size = 18
+power_batching = true
+num_queries = 229
+fri_folding_factors = [ 8, 8, 8, 8, 8, 8,]
+fri_early_stop_degree = 32
+grinding_query_phase = 16
+gap_to_radius = 0.005
+proof_size = "1.71 MB"
+[[circuits.lookups]]
+name = "Direct_gsum_[5000]"
+logup_type = "univariate"
+rows_L = 4194304
+rows_T = 0
+num_columns_S = 11
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Lookup_gsum_[5000]"
+logup_type = "univariate"
+rows_L = 0
+rows_T = 4194304
+num_columns_S = 11
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Range Check_gsum_[103]"
+logup_type = "univariate"
+rows_L = 4194304
+rows_T = 0
+num_columns_S = 1
+num_lookups_M = 4
+grinding_bits_lookup = 0
+
+
+[[circuits]]
+name = "BinaryExtension"
+group = "basic"
+trace_length = 4194304
+rho = 0.5
+air_max_degree = 3
+num_columns_fixed = 1
+num_columns_witness = 47
+num_columns = 48
+num_constraints = 8
+opening_points = 3
+batch_size = 40
+power_batching = true
+num_queries = 230
+fri_folding_factors = [ 8, 8, 8, 8, 8, 8,]
+fri_early_stop_degree = 32
+grinding_query_phase = 16
+gap_to_radius = 0.005999999999999999
+proof_size = "1.77 MB"
+[[circuits.lookups]]
+name = "Direct_gsum_[5000]"
+logup_type = "univariate"
+rows_L = 4194304
+rows_T = 0
+num_columns_S = 11
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Lookup_gsum_[124]"
+logup_type = "univariate"
+rows_L = 4194304
+rows_T = 0
+num_columns_S = 7
+num_lookups_M = 8
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Lookup_gsum_[5000]"
+logup_type = "univariate"
+rows_L = 0
+rows_T = 4194304
+num_columns_S = 11
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Range Check_gsum_[102]"
+logup_type = "univariate"
+rows_L = 4194304
+rows_T = 0
+num_columns_S = 1
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+
+[[circuits]]
+name = "Add256"
+group = "basic"
+trace_length = 1048576
+rho = 0.5
+air_max_degree = 3
+num_columns_fixed = 1
+num_columns_witness = 98
+num_columns = 99
+num_constraints = 36
+opening_points = 3
+batch_size = 69
+power_batching = true
+num_queries = 229
+fri_folding_factors = [ 8, 8, 8, 8, 8,]
+fri_early_stop_degree = 64
+grinding_query_phase = 16
+gap_to_radius = 0.005
+proof_size = "1.60 MB"
+[[circuits.lookups]]
+name = "Lookup_gsum_[5000]"
+logup_type = "univariate"
+rows_L = 0
+rows_T = 1048576
+num_columns_S = 11
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Permutation_gsum_[10]"
+logup_type = "univariate"
+rows_L = 1048576
+rows_T = 0
+num_columns_S = 6
+num_lookups_M = 16
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Range Check_gsum_[103]"
+logup_type = "univariate"
+rows_L = 1048576
+rows_T = 0
+num_columns_S = 1
+num_lookups_M = 16
+grinding_bits_lookup = 0
+
+
+[[circuits]]
+name = "ArithEq"
+group = "basic"
+trace_length = 1048576
+rho = 0.5
+air_max_degree = 3
+num_columns_fixed = 2
+num_columns_witness = 83
+num_columns = 85
+num_constraints = 103
+opening_points = 36
+batch_size = 470
+power_batching = true
+num_queries = 231
+fri_folding_factors = [ 8, 8, 8, 8, 8,]
+fri_early_stop_degree = 64
+grinding_query_phase = 16
+gap_to_radius = 0.007333333333333333
+proof_size = "1.59 MB"
+[[circuits.lookups]]
+name = "Lookup_gsum_[5000]"
+logup_type = "univariate"
+rows_L = 0
+rows_T = 1048576
+num_columns_S = 11
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Lookup_gsum_[5002]"
+logup_type = "univariate"
+rows_L = 1048576
+rows_T = 0
+num_columns_S = 2
+num_lookups_M = 2
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Permutation_gsum_[10]"
+logup_type = "univariate"
+rows_L = 1048576
+rows_T = 0
+num_columns_S = 6
+num_lookups_M = 2
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Range Check_gsum_[103, 104]"
+logup_type = "univariate"
+rows_L = 1048576
+rows_T = 0
+num_columns_S = 1
+num_lookups_M = 3
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Range Check_gsum_[103]"
+logup_type = "univariate"
+rows_L = 1048576
+rows_T = 0
+num_columns_S = 1
+num_lookups_M = 7
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Range Check_gsum_[108]"
+logup_type = "univariate"
+rows_L = 1048576
+rows_T = 0
+num_columns_S = 1
+num_lookups_M = 6
+grinding_bits_lookup = 0
+
+
+[[circuits]]
+name = "ArithEq384"
+group = "basic"
+trace_length = 1048576
+rho = 0.5
+air_max_degree = 3
+num_columns_fixed = 2
+num_columns_witness = 73
+num_columns = 75
+num_constraints = 76
+opening_points = 54
+batch_size = 536
+power_batching = true
+num_queries = 232
+fri_folding_factors = [ 8, 8, 8, 8, 8,]
+fri_early_stop_degree = 64
+grinding_query_phase = 16
+gap_to_radius = 0.007666666666666666
+proof_size = "1.58 MB"
+[[circuits.lookups]]
+name = "Lookup_gsum_[5000]"
+logup_type = "univariate"
+rows_L = 0
+rows_T = 1048576
+num_columns_S = 11
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Lookup_gsum_[5002]"
+logup_type = "univariate"
+rows_L = 1048576
+rows_T = 0
+num_columns_S = 2
+num_lookups_M = 2
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Permutation_gsum_[10]"
+logup_type = "univariate"
+rows_L = 1048576
+rows_T = 0
+num_columns_S = 6
+num_lookups_M = 2
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Range Check_gsum_[103, 104]"
+logup_type = "univariate"
+rows_L = 1048576
+rows_T = 0
+num_columns_S = 1
+num_lookups_M = 3
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Range Check_gsum_[103]"
+logup_type = "univariate"
+rows_L = 1048576
+rows_T = 0
+num_columns_S = 1
+num_lookups_M = 7
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Range Check_gsum_[108]"
+logup_type = "univariate"
+rows_L = 1048576
+rows_T = 0
+num_columns_S = 1
+num_lookups_M = 6
+grinding_bits_lookup = 0
+
+
+[[circuits]]
+name = "Keccakf"
+group = "basic"
+trace_length = 131072
+rho = 0.5
+air_max_degree = 3
+num_columns_fixed = 2
+num_columns_witness = 3016
+num_columns = 3018
+num_constraints = 2432
+opening_points = 26
+batch_size = 4065
+power_batching = true
+num_queries = 217
+fri_folding_factors = [ 8, 8, 8, 8,]
+fri_early_stop_degree = 64
+grinding_query_phase = 23
+gap_to_radius = 0.007333333333333333
+proof_size = "6.25 MB"
+[[circuits.lookups]]
+name = "Lookup_gsum_[126]"
+logup_type = "univariate"
+rows_L = 131072
+rows_T = 0
+num_columns_S = 4
+num_lookups_M = 534
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Lookup_gsum_[5000]"
+logup_type = "univariate"
+rows_L = 0
+rows_T = 131072
+num_columns_S = 11
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Permutation_gsum_[10]"
+logup_type = "univariate"
+rows_L = 131072
+rows_T = 0
+num_columns_S = 6
+num_lookups_M = 25
+grinding_bits_lookup = 0
+
+
+[[circuits]]
+name = "Sha256f"
+group = "basic"
+trace_length = 262144
+rho = 0.5
+air_max_degree = 3
+num_columns_fixed = 2
+num_columns_witness = 115
+num_columns = 117
+num_constraints = 115
+opening_points = 87
+batch_size = 1265
+power_batching = true
+num_queries = 231
+fri_folding_factors = [ 8, 8, 8, 8, 4,]
+fri_early_stop_degree = 32
+grinding_query_phase = 16
+gap_to_radius = 0.006666666666666666
+proof_size = "1.48 MB"
+[[circuits.lookups]]
+name = "Lookup_gsum_[5000]"
+logup_type = "univariate"
+rows_L = 0
+rows_T = 262144
+num_columns_S = 11
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Permutation_gsum_[10]"
+logup_type = "univariate"
+rows_L = 262144
+rows_T = 0
+num_columns_S = 6
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Range Check_gsum_[109]"
+logup_type = "univariate"
+rows_L = 262144
+rows_T = 0
+num_columns_S = 1
+num_lookups_M = 2
+grinding_bits_lookup = 0
+
+
+[[circuits]]
+name = "Poseidon2"
+group = "basic"
+trace_length = 131072
+rho = 0.25
+air_max_degree = 4
+num_columns_fixed = 2
+num_columns_witness = 66
+num_columns = 68
+num_constraints = 85
+opening_points = 17
+batch_size = 182
+power_batching = true
+num_queries = 114
+fri_folding_factors = [ 8, 8, 8, 8, 4,]
+fri_early_stop_degree = 32
+grinding_query_phase = 16
+gap_to_radius = 0.004
+proof_size = "698.25 KB"
+[[circuits.lookups]]
+name = "Lookup_gsum_[5000]"
+logup_type = "univariate"
+rows_L = 0
+rows_T = 131072
+num_columns_S = 11
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Permutation_gsum_[10]"
+logup_type = "univariate"
+rows_L = 131072
+rows_T = 0
+num_columns_S = 6
+num_lookups_M = 4
+grinding_bits_lookup = 0
+
+
+[[circuits]]
+name = "Blake2br"
+group = "basic"
+trace_length = 262144
+rho = 0.5
+air_max_degree = 3
+num_columns_fixed = 3
+num_columns_witness = 199
+num_columns = 202
+num_constraints = 189
+opening_points = 29
+batch_size = 651
+power_batching = true
+num_queries = 230
+fri_folding_factors = [ 8, 8, 8, 8, 4,]
+fri_early_stop_degree = 32
+grinding_query_phase = 16
+gap_to_radius = 0.005999999999999999
+proof_size = "1.61 MB"
+[[circuits.lookups]]
+name = "Lookup_gsum_[5000]"
+logup_type = "univariate"
+rows_L = 0
+rows_T = 262144
+num_columns_S = 11
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Permutation_gsum_[10]"
+logup_type = "univariate"
+rows_L = 262144
+rows_T = 0
+num_columns_S = 6
+num_lookups_M = 4
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Permutation_gsum_[127]"
+logup_type = "univariate"
+rows_L = 262144
+rows_T = 262144
+num_columns_S = 3
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Range Check_gsum_[103]"
+logup_type = "univariate"
+rows_L = 262144
+rows_T = 0
+num_columns_S = 1
+num_lookups_M = 12
+grinding_bits_lookup = 0
+
+
+[[circuits]]
+name = "SpecifiedRanges"
+group = "helper"
+trace_length = 1048576
+rho = 0.5
+air_max_degree = 3
+num_columns_fixed = 59
+num_columns_witness = 74
+num_columns = 133
+num_constraints = 16
+opening_points = 3
+batch_size = 107
+power_batching = true
+num_queries = 229
+fri_folding_factors = [ 8, 8, 8, 8, 8,]
+fri_early_stop_degree = 64
+grinding_query_phase = 16
+gap_to_radius = 0.005333333333333333
+proof_size = "1.84 MB"
+[[circuits.lookups]]
+name = "Lookup_gsum_[102]"
+logup_type = "univariate"
+rows_L = 0
+rows_T = 1048576
+num_columns_S = 1
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Lookup_gsum_[103, 104]"
+logup_type = "univariate"
+rows_L = 0
+rows_T = 1048576
+num_columns_S = 1
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Lookup_gsum_[104, 105, 106, 107, 108]"
+logup_type = "univariate"
+rows_L = 0
+rows_T = 1048576
+num_columns_S = 1
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Lookup_gsum_[104]"
+logup_type = "univariate"
+rows_L = 0
+rows_T = 1048576
+num_columns_S = 1
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Lookup_gsum_[108, 109]"
+logup_type = "univariate"
+rows_L = 0
+rows_T = 1048576
+num_columns_S = 1
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Lookup_gsum_[108]"
+logup_type = "univariate"
+rows_L = 0
+rows_T = 1048576
+num_columns_S = 1
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+
+[[circuits]]
+name = "VirtualTable0"
+group = "helper"
+trace_length = 2097152
+rho = 0.5
+air_max_degree = 3
+num_columns_fixed = 52
+num_columns_witness = 23
+num_columns = 75
+num_constraints = 6
+opening_points = 3
+batch_size = 69
+power_batching = true
+num_queries = 230
+fri_folding_factors = [ 8, 8, 8, 8, 8, 4,]
+fri_early_stop_degree = 32
+grinding_query_phase = 16
+gap_to_radius = 0.005666666666666667
+proof_size = "1.87 MB"
+[[circuits.lookups]]
+name = "Lookup_gsum_[124, 8001]"
+logup_type = "univariate"
+rows_L = 0
+rows_T = 2097152
+num_columns_S = 7
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Lookup_gsum_[125, 124]"
+logup_type = "univariate"
+rows_L = 0
+rows_T = 2097152
+num_columns_S = 7
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Lookup_gsum_[125]"
+logup_type = "univariate"
+rows_L = 0
+rows_T = 2097152
+num_columns_S = 7
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Lookup_gsum_[126, 331, 8002, 133, 125]"
+logup_type = "univariate"
+rows_L = 0
+rows_T = 2097152
+num_columns_S = 7
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Lookup_gsum_[330]"
+logup_type = "univariate"
+rows_L = 0
+rows_T = 2097152
+num_columns_S = 2
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+[[circuits.lookups]]
+name = "Lookup_gsum_[5002, 88, 77, 8003, 126]"
+logup_type = "univariate"
+rows_L = 0
+rows_T = 2097152
+num_columns_S = 4
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+
+[[circuits]]
+name = "VirtualTable1"
+group = "helper"
+trace_length = 2097152
+rho = 0.5
+air_max_degree = 3
+num_columns_fixed = 73
+num_columns_witness = 23
+num_columns = 96
+num_constraints = 6
+opening_points = 3
+batch_size = 90
+power_batching = true
+num_queries = 230
+fri_folding_factors = [ 8, 8, 8, 8, 8, 4,]
+fri_early_stop_degree = 32
+grinding_query_phase = 16
+gap_to_radius = 0.005999999999999999
+proof_size = "1.91 MB"
+[[circuits.lookups]]
+name = "Lookup_gsum_[5000]"
+logup_type = "univariate"
+rows_L = 0
+rows_T = 2097152
+num_columns_S = 8
+num_lookups_M = 1
+grinding_bits_lookup = 0
+
+
+[[circuits]]
+name = "DmaPrePost-compressor"
+group = "compression"
+trace_length = 262144
+rho = 0.25
+air_max_degree = 5
+num_columns_fixed = 58
+num_columns_witness = 107
+num_columns = 165
+num_constraints = 179
+opening_points = 6
+batch_size = 198
+power_batching = true
+num_queries = 110
+fri_folding_factors = [ 8, 8, 8, 8, 8,]
+fri_early_stop_degree = 32
+grinding_query_phase = 20
+gap_to_radius = 0.004666666666666667
+proof_size = "791.32 KB"
+[[circuits.lookups]]
+name = "Connection_gprod_[1]"
+logup_type = "univariate"
+rows_L = 262144
+rows_T = 262144
+num_columns_S = 2
+num_lookups_M = 36
+grinding_bits_lookup = 0
+
+
+[[circuits]]
+name = "ArithEq-compressor"
+group = "compression"
+trace_length = 262144
+rho = 0.25
+air_max_degree = 5
+num_columns_fixed = 58
+num_columns_witness = 107
+num_columns = 165
+num_constraints = 179
+opening_points = 6
+batch_size = 198
+power_batching = true
+num_queries = 110
+fri_folding_factors = [ 8, 8, 8, 8, 8,]
+fri_early_stop_degree = 32
+grinding_query_phase = 20
+gap_to_radius = 0.004666666666666667
+proof_size = "791.32 KB"
+[[circuits.lookups]]
+name = "Connection_gprod_[1]"
+logup_type = "univariate"
+rows_L = 262144
+rows_T = 262144
+num_columns_S = 2
+num_lookups_M = 36
+grinding_bits_lookup = 0
+
+
+[[circuits]]
+name = "ArithEq384-compressor"
+group = "compression"
+trace_length = 262144
+rho = 0.25
+air_max_degree = 5
+num_columns_fixed = 58
+num_columns_witness = 107
+num_columns = 165
+num_constraints = 179
+opening_points = 6
+batch_size = 198
+power_batching = true
+num_queries = 110
+fri_folding_factors = [ 8, 8, 8, 8, 8,]
+fri_early_stop_degree = 32
+grinding_query_phase = 20
+gap_to_radius = 0.004666666666666667
+proof_size = "791.32 KB"
+[[circuits.lookups]]
+name = "Connection_gprod_[1]"
+logup_type = "univariate"
+rows_L = 262144
+rows_T = 262144
+num_columns_S = 2
+num_lookups_M = 36
+grinding_bits_lookup = 0
+
+
+[[circuits]]
+name = "Keccakf-compressor"
+group = "compression"
+trace_length = 1048576
+rho = 0.25
+air_max_degree = 5
+num_columns_fixed = 58
+num_columns_witness = 107
+num_columns = 165
+num_constraints = 179
+opening_points = 6
+batch_size = 198
+power_batching = true
+num_queries = 110
+fri_folding_factors = [ 8, 8, 8, 8, 8, 4,]
+fri_early_stop_degree = 32
+grinding_query_phase = 20
+gap_to_radius = 0.006333333333333333
+proof_size = "905.29 KB"
+[[circuits.lookups]]
+name = "Connection_gprod_[1]"
+logup_type = "univariate"
+rows_L = 1048576
+rows_T = 1048576
+num_columns_S = 2
+num_lookups_M = 36
+grinding_bits_lookup = 0
+
+
+[[circuits]]
+name = "Sha256f-compressor"
+group = "compression"
+trace_length = 524288
+rho = 0.25
+air_max_degree = 5
+num_columns_fixed = 58
+num_columns_witness = 107
+num_columns = 165
+num_constraints = 179
+opening_points = 6
+batch_size = 198
+power_batching = true
+num_queries = 110
+fri_folding_factors = [ 8, 8, 8, 8, 8,]
+fri_early_stop_degree = 64
+grinding_query_phase = 20
+gap_to_radius = 0.005333333333333333
+proof_size = "853.95 KB"
+[[circuits.lookups]]
+name = "Connection_gprod_[1]"
+logup_type = "univariate"
+rows_L = 524288
+rows_T = 524288
+num_columns_S = 2
+num_lookups_M = 36
+grinding_bits_lookup = 0
+
+
+[[circuits]]
+name = "Blake2br-compressor"
+group = "compression"
+trace_length = 262144
+rho = 0.25
+air_max_degree = 5
+num_columns_fixed = 58
+num_columns_witness = 107
+num_columns = 165
+num_constraints = 179
+opening_points = 6
+batch_size = 198
+power_batching = true
+num_queries = 110
+fri_folding_factors = [ 8, 8, 8, 8, 8,]
+fri_early_stop_degree = 32
+grinding_query_phase = 20
+gap_to_radius = 0.004666666666666667
+proof_size = "791.32 KB"
+[[circuits.lookups]]
+name = "Connection_gprod_[1]"
+logup_type = "univariate"
+rows_L = 262144
+rows_T = 262144
+num_columns_S = 2
+num_lookups_M = 36
+grinding_bits_lookup = 0
+
+
+[[circuits]]
+name = "Recursive2"
+group = "aggregation"
+trace_length = 131072
+rho = 0.125
+air_max_degree = 8
+num_columns_fixed = 49
+num_columns_witness = 71
+num_columns = 120
+num_constraints = 158
+opening_points = 4
+batch_size = 145
+power_batching = true
+num_queries = 73
+fri_folding_factors = [ 8, 8, 8, 8, 8,]
+fri_early_stop_degree = 32
+grinding_query_phase = 20
+gap_to_radius = 0.004
+proof_size = "565.01 KB"
+[[circuits.lookups]]
+name = "Connection_gprod_[1]"
+logup_type = "univariate"
+rows_L = 131072
+rows_T = 131072
+num_columns_S = 2
+num_lookups_M = 27
+grinding_bits_lookup = 0
+
+
+[[circuits]]
+name = "Final"
+group = "final"
+trace_length = 65536
+rho = 0.03125
+air_max_degree = 8
+num_columns_fixed = 55
+num_columns_witness = 80
+num_columns = 135
+num_constraints = 161
+opening_points = 4
+batch_size = 158
+power_batching = true
+num_queries = 43
+fri_folding_factors = [ 16, 16, 16, 16,]
+fri_early_stop_degree = 32
+grinding_query_phase = 22
+gap_to_radius = 0.0036666666666666666
+proof_size = "335.21 KB"
+[[circuits.lookups]]
+name = "Connection_gprod_[1]"
+logup_type = "univariate"
+rows_L = 65536
+rows_T = 65536
+num_columns_S = 2
+num_lookups_M = 33
+grinding_bits_lookup = 0
+
+
+[[circuits]]
+name = "Final_Compressed"
+group = "final_compressed"
+trace_length = 32768
+rho = 0.0625
+air_max_degree = 8
+num_columns_fixed = 49
+num_columns_witness = 71
+num_columns = 120
+num_constraints = 158
+opening_points = 4
+batch_size = 145
+power_batching = true
+num_queries = 54
+fri_folding_factors = [ 8, 8, 8,]
+fri_early_stop_degree = 1024
+grinding_query_phase = 22
+gap_to_radius = 0.003333333333333333
+proof_size = "254.64 KB"
+[[circuits.lookups]]
+name = "Connection_gprod_[1]"
+logup_type = "univariate"
+rows_L = 32768
+rows_T = 32768
+num_columns_S = 2
+num_lookups_M = 27
+grinding_bits_lookup = 0
+
+
+[zkevm]
+name = "Venus"
+protocol_family = "FRI_STARK"
+version = "0.1.6"
+field = "Goldilocks^3"
+hash_size_bits = 256


### PR DESCRIPTION
Add soundcalc integration for [Venus](https://github.com/cysic-labs/venus) (Cysic Labs), a performance zkVM based on ZisK, targeting Goldilocks³ with GPU/FPGA acceleration.

## What's included

- `soundcalc/zkvms/venus/venus.toml` — 44 circuits, all parameters derived from Venus v0.1.6 proving key
- `soundcalc/zkvms/venus/__init__.py` — loader
- `soundcalc/main.py` — register Venus
- `reports/venus.md` — generated report
- `reports/summary.md` — add Venus to summary table

## Key numbers

- **Security:** 128 bits (JBR), 111 bits (UDR)
- **Proof size:** 313 KiB
- **Weakest circuit:** Dma
- **Field:** Goldilocks³ (cubic extension)
- **PCS:** FRI-STARK

## Methodology

All parameters (FRI, AIR, lookups, proof\_size) extracted from Venus v0.1.6 proving key using `proofman-cli soundness`. Cross-validated against ZisK upstream CLI — soundness parameters are identical, as Venus shares the same PIL circuit definitions.